### PR TITLE
Adding Panelist Bluff the Listener Statistics Report

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,7 +16,7 @@ from werkzeug.exceptions import HTTPException
 
 from reports.guest import best_of_only, scores as guest_scores
 from reports.panelist import (aggregate_scores, appearances_by_year,
-                              gender_mix, gender_stats,
+                              bluff_stats, gender_mix, gender_stats,
                               panelist_vs_panelist as pvp,
                               rankings_summary,
                               single_appearance as single,
@@ -28,7 +28,7 @@ from reports.show import (all_women_panel, guest_hosts, guest_scorekeeper,
                           high_scoring, lightning_round, show_details)
 
 #region Global Constants
-APP_VERSION = "1.4.8"
+APP_VERSION = "1.4.9"
 RANK_MAP = {
     "1": "First",
     "1t": "First Tied",
@@ -185,6 +185,15 @@ def panelist_appearances_by_year():
     return render_template("panelist/appearances_by_year.html",
                            panelists=panelists,
                            show_years=show_years)
+
+@app.route("/panelist/bluff_stats")
+def panelist_bluff_stats():
+    """Panelist Bluff the Listener Statistics Report"""
+    database_connection.reconnect()
+    panelists = bluff_stats.retrieve_all_panelist_bluff_stats(database_connection)
+
+    return render_template("panelist/bluff_stats.html",
+                           panelists=panelists)
 
 @app.route("/panelist/gender_stats")
 def panelist_gender_stats():

--- a/reports/panelist/__init__.py
+++ b/reports/panelist/__init__.py
@@ -3,14 +3,20 @@
 # reports.wwdt.me is relased under the terms of the Apache License 2.0
 """Explicitly listing all panelist reporting modules"""
 
-from reports.panelist import (aggregate_scores, appearances_by_year,
-                              gender_mix, gender_stats, panelist_vs_panelist,
-                              rankings_summary, single_appearance,
+from reports.panelist import (aggregate_scores,
+                              appearances_by_year,
+                              bluff_stats,
+                              gender_mix,
+                              gender_stats,
+                              panelist_vs_panelist,
+                              rankings_summary,
+                              single_appearance,
                               stats_summary, streaks)
 
 __all__ = [
     "aggregate_scores",
     "appearances_by_year",
+    "bluff_stats",
     "gender_mix",
     "gender_stats",
     "panelist_vs_panelist",

--- a/reports/panelist/bluff_stats.py
+++ b/reports/panelist/bluff_stats.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018-2020 Linh Pham
+# reports.wwdt.me is relased under the terms of the Apache License 2.0
+"""WWDTM Panelist Bluff the Listener Statistics Report Functions"""
+
+from collections import OrderedDict
+from typing import Dict, List
+import mysql.connector
+
+#region Retrieval Functions
+def retrieve_all_panelists(database_connection: mysql.connector.connect
+                          ) -> List[Dict]:
+    """Retrieves a dictionary for all available panelists from the
+    database"""
+
+    cursor = database_connection.cursor(dictionary=True)
+    query = ("SELECT p.panelistid, p.panelist, p.panelistslug "
+             "FROM ww_panelists p "
+             "WHERE p.panelist <> '<Multiple>' "
+             "ORDER BY p.panelistslug ASC;")
+    cursor.execute(query)
+    result = cursor.fetchall()
+    cursor.close()
+
+    if not result:
+        return None
+
+    panelists = []
+    for row in result:
+        panelist = OrderedDict()
+        panelist["id"] = row["panelistid"]
+        panelist["slug"] = row["panelistslug"]
+        panelist["name"] = row["panelist"]
+        panelists.append(panelist)
+
+    return panelists
+
+def retrieve_panelist_bluff_counts(panelist_id: int,
+                                   database_connection: mysql.connector.connect
+                                  ) -> Dict:
+    """Retrieves a dictionary containing the count of the number of
+    times a panelist's Bluff story was chosen and the number of times
+    a panelist had the correct story"""
+
+    counts = OrderedDict()
+    cursor = database_connection.cursor(dictionary=True)
+    query = ("SELECT ( "
+             "SELECT COUNT(blm.showid) FROM ww_showbluffmap blm "
+             "JOIN ww_panelists p ON p.panelistid = blm.chosenbluffpnlid "
+             "JOIN ww_shows s ON s.showid = blm.showid "
+             "WHERE blm.chosenbluffpnlid = %s "
+             "AND s.repeatshowid IS NULL ) AS chosen, ( "
+             "SELECT COUNT(blm.showid) FROM ww_showbluffmap blm "
+             "JOIN ww_panelists p ON p.panelistid = blm.correctbluffpnlid "
+             "JOIN ww_shows s ON s.showid = blm.showid "
+             "WHERE blm.correctbluffpnlid = %s "
+             "AND s.repeatshowid IS NULL ) AS correct;")
+    cursor.execute(query, (panelist_id, panelist_id, ))
+    result = cursor.fetchone()
+
+    if not result:
+        counts["chosen"] = 0
+        counts["correct"] = 0
+    else:
+        counts["chosen"] = result["chosen"]
+        counts["correct"] = result["correct"]
+
+    cursor = database_connection.cursor(dictionary=True)
+    query = ("SELECT COUNT(s.showdate) as appearances "
+             "FROM ww_showpnlmap pm "
+             "JOIN ww_shows s ON s.showid = pm.showid "
+             "JOIN ww_showdescriptions sd ON sd.showid = pm.showid "
+             "JOIN ww_showbluffmap blm ON blm.showid = pm.showid "
+             "WHERE pm.panelistid = %s "
+             "AND s.repeatshowid IS NULL "
+             "AND sd.showdescription LIKE '%bluff%' "
+             "AND (blm.chosenbluffpnlid IS NOT NULL "
+             "AND blm.correctbluffpnlid IS NOT NULL) "
+             "ORDER BY s.showdate ASC;")
+    cursor.execute(query, (panelist_id, ))
+    result = cursor.fetchone()
+
+    if not result:
+        counts["appearances"] = None
+    else:
+        counts["appearances"] = result["appearances"]
+
+    return counts
+
+def retrieve_all_panelist_bluff_stats(database_connection: mysql.connector.connect
+                                     ) -> List[Dict]:
+    """Retrieves a list of Bluff the Listener statistics for all
+    panelists"""
+
+    panelists = retrieve_all_panelists(database_connection)
+
+    if not panelists:
+        return None
+
+    stats = []
+    for panelist in panelists:
+        counts = retrieve_panelist_bluff_counts(panelist["id"],
+                                                database_connection)
+        if counts  and (counts["correct"] or counts["chosen"]):
+            panelist.update(counts)
+            stats.append(panelist)
+
+    return stats
+
+#endregion

--- a/static/css/panelist/bluff_stats.css
+++ b/static/css/panelist/bluff_stats.css
@@ -1,0 +1,4 @@
+@media all {
+    col.panelist-name { width: 15rem; }
+    col.panelist-bluff-chosen, col.panelist-bluff-correct, col.panelist-bluff-appearances { width: 5rem; }
+}

--- a/templates/core/sitemap.xml
+++ b/templates/core/sitemap.xml
@@ -25,6 +25,10 @@
     <changefreq>weekly</changefreq>
   </url>
   <url>
+    <loc>{{ site_url }}{{ url_for("panelist_bluff_stats") }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
     <loc>{{ site_url }}{{ url_for("panelist_appearances_by_year") }}</loc>
     <changefreq>weekly</changefreq>
   </url>

--- a/templates/index.html
+++ b/templates/index.html
@@ -125,8 +125,7 @@
             </td>
         </tr>
         <tr>
-            <td><a href="{{ url_for('panelist_bluff_stats') }}">Panelist Bluff the Listener
-                Stats</a></td>
+            <td><a href="{{ url_for('panelist_bluff_stats') }}">Bluff the Listener Statistics</a></td>
             <td>
                 A report providing a breakdown of the number of times each panelist
                 had their Bluff the Listener story chosen, had the correct story, and

--- a/templates/index.html
+++ b/templates/index.html
@@ -125,6 +125,15 @@
             </td>
         </tr>
         <tr>
+            <td><a href="{{ url_for('panelist_bluff_stats') }}">Panelist Bluff the Listener
+                Stats</a></td>
+            <td>
+                A report providing a breakdown of the number of times each panelist
+                had their Bluff the Listener story chosen, had the correct story, and
+                the number of appearances on shows that had a Bluff the Listener segment.
+            </td>
+        </tr>
+        <tr>
             <td><a href="{{ url_for('panelist_panel_gender_mix') }}">Panel Gender Mix</a></td>
             <td>
                 A break down of the panel gender mix for each show by year

--- a/templates/panelist/bluff_stats.html
+++ b/templates/panelist/bluff_stats.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% block css %}panelist/bluff_stats.css{% endblock %}
+{% block title %}Panelist Bluff the Listener Statistics Report{% endblock %}
+{% block header_title %}Panelist Bluff the Listener Statistics Report{% endblock %}
+{% block synopsis %}
+<p>
+    This report provides a breakdown of the number of times each panelist
+    had their Bluff the Listener story chosen, had the correct story, and
+    the number of appearances on shows that had a Bluff the Listener segment.
+    The appearance count includes Best Of shows that have unique Bluff the
+    Listener segments that appeared on taped shows that were never broadcasted.
+</p>
+<p>
+    Please note that the data for Bluff the Listener is not complete as audio
+    from shows aired in 1998 and 1999 are not publicly available. Thus,
+    panelists that do not appear on this list do not have any Bluff the
+    Listener information entered from those shows.
+</p>
+{% endblock %}
+{% block breadcrumb %}
+<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
+{% endblock %}
+{% block content %}
+<!-- Start Panelist Bluff the Listener Stats Section -->
+<table class="pure-table pure-table-bordered">
+    <colgroup>
+        <col class="panelist-name">
+        <col class="panelist-bluff-chosen">
+        <col class="panelist-bluff-correct">
+        <col class="panelist-bluff-appearances">
+    </colgroup>
+    <thead>
+        <tr>
+            <th scope="col">Panelist</th>
+            <th scope="col">Chosen</th>
+            <th scope="col">Correct</th>
+            <th scope="col">Appearances</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for panelist in panelists %}
+        <tr>
+            <td><a href="{{ stats_url }}/panelists/{{ panelist.slug }}">
+                {{ panelist.name }}</a></td>
+            <td>{{ panelist.chosen }}</td>
+            <td>{{ panelist.correct }}</td>
+            <td>{{ panelist.appearances }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+    <tfoot>
+        <tr>
+            <th scope="col">Panelist</th>
+            <th scope="col">Chosen</th>
+            <th scope="col">Correct</th>
+            <th scope="col">Bluff Appearances</th>
+        </tr>
+    </tfoot>
+</table>
+<!-- End Panelist Bluff the Listener Stats Section -->
+{% endblock %}


### PR DESCRIPTION
New report that provides a list of panelists along with the counts of chosen and correct Bluff the Listener stories and number of shows that each have been on with a Bluff the Listener segment