### PR TITLE
Restructuring templates and page breadcrumbs

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ from reports.show import (all_women_panel, guest_hosts, guest_scorekeeper,
                           high_scoring, lightning_round, show_details)
 
 #region Global Constants
-APP_VERSION = "1.5.1"
+APP_VERSION = "1.6.0"
 RANK_MAP = {
     "1": "First",
     "1t": "First Tied",
@@ -106,8 +106,8 @@ def sitemap_xml():
 #region Guest Reports
 @app.route("/guest")
 def get_guest():
-    """Redirect /guest to /"""
-    return redirect(url_for("index"))
+    """Guest Reports Landing Page"""
+    return render_template("guest/index.html")
 
 @app.route("/guest/best_of_only")
 def guest_best_of_only():
@@ -140,8 +140,8 @@ def guest_three_pointers():
 #region Location Reports
 @app.route("/location")
 def get_location():
-    """Redirect /location to /"""
-    return redirect(url_for("index"))
+    """Location Reports Landing Page"""
+    return render_template("location/index.html")
 
 @app.route("/location/average_scores")
 def location_average_scores():
@@ -157,8 +157,8 @@ def location_average_scores():
 #region Panelist Reports
 @app.route("/panelist")
 def get_panelist():
-    """Redirect /panelist to /"""
-    return redirect(url_for("index"))
+    """Panelist Reports Landing Page"""
+    return render_template("panelist/index.html")
 
 @app.route("/panelist/aggregate_scores")
 def panelist_aggregate_scores():
@@ -299,8 +299,8 @@ def panelist_win_streaks():
 #region Scorekeeper Reports
 @app.route("/scorekeeper")
 def get_scorekeeper():
-    """Redirect /scorekeeper to /"""
-    return redirect(url_for("index"))
+    """Scorekeeper Reports Landing Page"""
+    return render_template("scorekeeper/index.html")
 
 @app.route("/scorekeeper/introductions")
 def scorekeeper_introductions():
@@ -318,8 +318,8 @@ def scorekeeper_introductions():
 #region Show Reports
 @app.route("/show")
 def get_show():
-    """Redirect /show to /"""
-    return redirect(url_for("index"))
+    """Show Reports Landing Page"""
+    return render_template("show/index.html")
 
 @app.route("/show/all_shows")
 def show_all_shows():

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1,3 +1,4 @@
 @media all {
-    col.report-name { width: 16rem; }
+    section { border-bottom: 1px #aaa solid; margin: 0.5rem 0; padding-bottom: 0.5rem; }
+    section#toc, section#summary { border: none; margin: 0; }
 }

--- a/static/css/panelist/appearances_by_year.css
+++ b/static/css/panelist/appearances_by_year.css
@@ -1,4 +1,5 @@
 @media all {
+    body { max-width: initial !important; }
     #results { max-height: 80vh; overflow: scroll; }
     table.pure-table { margin-right: 0.25rem; width: initial; }
     table.pure-table thead, table.pure-table tfoot { background-color: skyblue; font-weight: 600; text-align: center; }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,14 +1,25 @@
 @media all {
     html, button, input, select, textarea, .pure-g [class *= "pure-u"] { font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { max-width: 72rem; }
     pre, code { font-family: "IBM Plex Mono", "Consolas", "Monaco", monospace; }
     body {  margin: 1.5rem; }
     h1 { font-size: 1.5rem; font-weight: 700; }
     h2 { font-size: 1.25rem; font-weight: 700; margin: 1.5rem 0 1rem; }
+    h3 { font-size: 1.175rem; font-weight: 700; }
+    h4 { font-size: 1.1rem; font-weight: 500; }
+    #breadcrumb { margin: 0; padding: 0; }
+    #breadcrumb ul { list-style: none; padding: 0; }
+    #breadcrumb ul li { display: inline; padding: 0; }
+    #breadcrumb ul li:first-child { padding: 0; }
+    #breadcrumb ul li:not(:last-child)::after { content: ">"; margin: 0 0.75rem;  }
     table.pure-table { max-width: 72rem; }
     table.pure-table td { vertical-align: top; }
     table.pure-table thead, table.pure-table tfoot { background-color: lightgray !important; font-weight: 700; text-align: center; vertical-align: middle; }
     td.no-data { background-color: rgb(240, 240, 240); }
     footer { font-size: 0.9rem; margin-top: 1.5rem; }
+    dl { margin-left: 0.5rem; }
+    dt { font-size: 1.1rem; font-weight: 500; margin: 0.5rem 0; }
+    dd { margin: 0.75rem 0 0.75rem 1rem; }
 }
 
 @media only screen and (max-width: 480px) {

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+<head>    
+    {% block head %}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}{% endblock %} | Wait Wait Don't Tell Me! Reports</title>
@@ -11,7 +12,6 @@
 
     <!-- Import Custom CSS -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/') }}{% block css %}{% endblock %}">
 
     {% if ga_property_code %}
     <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -23,16 +23,20 @@
     gtag('config', '{{ ga_property_code }}');
     </script>
     {% endif %}
+    {% endblock head %}
 </head>
+
 <body>
 <header>
+    <h1>Wait Wait... Don't Tell Me! Reports</h1>
     {% block breadcrumb %}{% endblock %}
-    <h1>{% block header_title %}{% endblock %}</h1>
-    {% block synopsis %}{% endblock %}
 </header>
 
 <main>
+    {% block main %}    
+    {% block synopsis %}{% endblock %}
     {% block content %}{% endblock %}
+    {% endblock main %}
 </main>
 
 <footer>

--- a/templates/core/sitemap.xml
+++ b/templates/core/sitemap.xml
@@ -5,6 +5,10 @@
     <changefreq>daily</changefreq>
   </url>
   <url>
+    <loc>{{ site_url }}{{ url_for("get_guest") }}</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
     <loc>{{ site_url }}{{ url_for("guest_best_of_only") }}</loc>
     <changefreq>weekly</changefreq>
   </url>
@@ -17,8 +21,16 @@
     <changefreq>weekly</changefreq>
   </url>
   <url>
+    <loc>{{ site_url }}{{ url_for("get_location") }}</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
     <loc>{{ site_url }}{{ url_for("location_average_scores") }}</loc>
     <changefreq>weekly</changefreq>
+  </url>
+  <url>
+    <loc>{{ site_url }}{{ url_for("get_panelist") }}</loc>
+    <changefreq>monthly</changefreq>
   </url>
   <url>
     <loc>{{ site_url }}{{ url_for("panelist_aggregate_scores") }}</loc>
@@ -65,8 +77,16 @@
     <changefreq>weekly</changefreq>
   </url>
   <url>
+    <loc>{{ site_url }}{{ url_for("get_scorekeeper") }}</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
     <loc>{{ site_url }}{{ url_for("scorekeeper_introductions") }}</loc>
     <changefreq>weekly</changefreq>
+  </url>
+  <url>
+    <loc>{{ site_url }}{{ url_for("get_show") }}</loc>
+    <changefreq>monthly</changefreq>
   </url>
   <url>
     <loc>{{ site_url }}{{ url_for("show_all_shows") }}</loc>

--- a/templates/errors/500.html
+++ b/templates/errors/500.html
@@ -1,6 +1,10 @@
 {% extends "errors/base.html" %}
-{% block css %}500.css{% endblock %}
-{% block title %}Error 500{% endblock %}
+{% block title %}500 | Error{% endblock %}
+
+{% block head %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/500.css') }}">
+{% endblock head %}
 
 {% block content %}
 <h1>Oops...</h1>
@@ -8,4 +12,4 @@
 
 <h2>Error Details</h2>
 <pre class="traceback">{{ error_traceback }}</pre>
-{% endblock %}
+{% endblock content %}

--- a/templates/errors/base.html
+++ b/templates/errors/base.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    {% block head %}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}{% endblock %} | Wait Wait Don't Tell Me! Reports</title>
@@ -11,7 +12,7 @@
 
     <!-- Import Custom CSS -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/') }}{% block css %}{% endblock %}">
+    
 
     {% if ga_property_code %}
     <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -23,10 +24,13 @@
     gtag('config', '{{ ga_property_code }}');
     </script>
     {% endif %}
+    {% endblock head %}
 </head>
 <body>
 <main>
+    {% block main %}
     {% block content %}{% endblock %}
+    {% endblock main %}
 </main>
 
 <footer>

--- a/templates/guest/_reports.html
+++ b/templates/guest/_reports.html
@@ -1,0 +1,28 @@
+<dl>
+    <dt>
+        <a href="{{ url_for('guest_best_of_only') }}">Best Of Only Guests</a>
+    </dt>
+    <dd>
+        A listing of Not My Job guests that have appeared on Best Of shows but
+        not regular shows; due to, appearing on shows that were part of the
+        show's second taping when traveling away from their home base of
+        Chicago, Illinois.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('guest_scoring_exceptions') }}">Scoring Exceptions</a>
+    </dt>
+    <dd>
+        A list of Not My Job guests who have had scoring exceptions that allowed
+        them to win the prize for the listener contestant or were awarded the
+        full three points.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('guest_three_pointers') }}">Three Pointers</a>
+    </dt>
+    <dd>
+        A list of all of the Not My Job guests who answered all three Not My Job
+        questions correctly or were awarded all three points.
+    </dd>
+</dl>

--- a/templates/guest/best_of_only.html
+++ b/templates/guest/best_of_only.html
@@ -1,11 +1,22 @@
 {% extends "base.html" %}
-{% block css %}guest/best_of_only.css{% endblock %}
-{% block title %}Best Of Only Not My Job Guests{% endblock %}
-{% block header_title %}Best Of Only Not My Job Guests{% endblock %}
+{% block title %}Best Of Only Not My Job Guests | Guest{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/guest/best_of_only.css') }}">
+{% endblock head %}
+
 {% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_guest') }}">Guest</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Best Of Only Not My Job Guests</h2>
 <p>
     With Wait Wait... Don't Tell Me! recording two shows when they travel to
     some cities; in which, the Thursday taping getting aired that weekend and
@@ -17,7 +28,8 @@
     This report lists out all of the Not My Job guests that have only appeared
     on Best Of shows and not regular shows.
 </p>
-{% endblock %}
+{% endblock synopsis%}
+
 {% block content %}
 <!-- Start Best Of Only Guest Section -->
 <table class="pure-table pure-table-bordered">

--- a/templates/guest/index.html
+++ b/templates/guest/index.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Guest Reports{% endblock %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li>Guest</li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
+{% block synopsis %}
+<h2>Guest Reports</h2>
+{% endblock synopsis %}
+
+{% block content %}
+{% include "guest/_reports.html" %}
+{% endblock content %}

--- a/templates/guest/scoring_exceptions.html
+++ b/templates/guest/scoring_exceptions.html
@@ -1,17 +1,29 @@
 {% extends "base.html" %}
-{% block css %}guest/scoring_exceptions.css{% endblock %}
-{% block title %}Not My Job Scoring Exceptions{% endblock %}
-{% block header_title %}Not My Job Scoring Exceptions{% endblock %}
+{% block title %}Not My Job Scoring Exceptions | Guest{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/guest/scoring_exceptions.css') }}">
+{% endblock head %}
+
 {% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_guest') }}">Guest</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Not My Job Scoring Exceptions</h2>
 <p>
     List of Not My Job guests who have had scoring exceptions that allowed them
     to win the prize for the listener contestant or were awarded the full three
     points.
 </p>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Not My Job Scoring Exceptions Section -->
 <table class="pure-table pure-table-bordered">
@@ -79,4 +91,4 @@
     </tfoot>
 </table>
 <!-- End Not My Job Scoring Exceptions Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/guest/three_pointers.html
+++ b/templates/guest/three_pointers.html
@@ -1,16 +1,28 @@
 {% extends "base.html" %}
-{% block css %}guest/three_pointers.css{% endblock %}
-{% block title %}Not My Job Three Pointers{% endblock %}
-{% block header_title %}Not My Job Three Pointers{% endblock %}
+{% block title %}Not My Job Three Pointers | Guest{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/guest/three_pointers.css') }}">
+{% endblock head %}
+
 {% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_guest') }}">Guest</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Not My Job Three Pointers</h2>
 <p>
     List of all of the Not My Job guests who answered all three Not My Job
     questions correctly or were awarded all three points.
 </p>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Not My Job Scoring Exceptions Section -->
 <table class="pure-table pure-table-bordered">
@@ -60,4 +72,4 @@
     </tfoot>
 </table>
 <!-- End Not My Job Scoring Exceptions Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,312 +1,57 @@
 {% extends "base.html" %}
-{% block css %}index.css{% endblock %}
 {% block title %}Home{% endblock %}
-{% block header_title %}Wait Wait... Don't Tell Me! Reports{% endblock %}
-{% block content %}
-<!-- Start Table of Contents -->
-<div id="toc">
-    <h2>Available Report Categories</h2>
-    <ul>
-        <li><a href="#guest">Guest</a></li>
-        <li><a href="#location">Location</a></li>
-        <li><a href="#panelist">Panelist</a></li>
-        <li><a href="#scorekeeper">Scorekeeper</a></li>
-        <li><a href="#show">Show</a></li>
-    </ul>
-</div>
-<!-- End Table of Contents -->
 
-<div id="summary">
+{% block head %}
+{{ super() }}
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/index.css') }}">
+{% endblock head %}
+
+{% block synopsis %}
+<section id="summary">
+<p>
     This site provides reports on various aspects of the data recorded in the
     <a href="{{ stats_url }}">Wait Wait... Don't Tell Me! Stats and Show Details</a>
     database that don't really fit neatly into the main Stats and Show Details
     site.
-</div>
+</p>
+</section>    
+{% endblock synopsis %}
 
-<!-- Start Guest Reports -->
-<h2 id="guest">Guest</h2>
-<table class="pure-table pure-table-bordered">
-    <colgroup>
-        <col class="report-name">
-        <col class="report-description">
-    </colgroup>
-    <thead>
-        <tr>
-            <th>Report</th>
-            <th>Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><a href="{{ url_for('guest_best_of_only') }}">Best Of Only Guests</a></td>
-            <td>
-                A listing of Not My Job guests that have appeared on Best Of
-                shows but not regular shows; due to, appearing on shows that
-                were part of the show's second taping when traveling away from
-                their home base of Chicago, Illinois.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('guest_scoring_exceptions') }}">Scoring Exceptions</a></td>
-            <td>
-                A list of Not My Job guests who have had scoring exceptions
-                that allowed them to win the prize for the listener contestant
-                or were awarded the full three points.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('guest_three_pointers') }}">Three Pointers</a></td>
-            <td>
-                A list of all of the Not My Job guests who answered all three
-                Not My Job questions correctly or were awarded all three
-                points.
-            </td>
-        </tr>
-    </tbody>
-</table>
+{% block content %}
+<section id="toc">
+<h2>Available Report Categories</h2>
+<ul>
+    <li><a href="#guest">Guest</a></li>
+    <li><a href="#location">Location</a></li>
+    <li><a href="#panelist">Panelist</a></li>
+    <li><a href="#scorekeeper">Scorekeeper</a></li>
+    <li><a href="#show">Show</a></li>
+</ul>
+</section>
 
-<!-- End Guest Reports-->
+<section id="guest">
+<h2>Guest</h2>
+{% include "guest/_reports.html" %}
+</section>
 
-<!-- Start Location Reports -->
-<h2 id="location">Location</h2>
-<table class="pure-table pure-table-bordered">
-    <colgroup>
-        <col class="report-name">
-        <col class="report-description">
-    </colgroup>
-    <thead>
-        <tr>
-            <th>Report</th>
-            <th>Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><a href="{{ url_for('location_average_scores') }}">Average Scores by Location</a></td>
-            <td>
-                A listing of the average panelist score and average total score
-                for each location the show has broadcasted from. The exception
-                is the 25th Anniversary Special that aired on October 27, 2018
-                due to the unique Lightning Fill-in-the-Blank format used.
-            </td>
-        </tr>
-    </tbody>
-</table>
-<!-- End Location Reports -->
+<section id="location">
+<h2>Location</h2>
+{% include "location/_reports.html" %}
+</section>
 
-<!-- Start Panelist Reports -->
-<h2 id="panelist">Panelist</h2>
-<table class="pure-table pure-table-bordered">
-    <colgroup>
-        <col class="report-name">
-        <col class="report-description">
-    </colgroup>
-    <thead>
-        <tr>
-            <th>Report</th>
-            <th>Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><a href="{{ url_for('panelist_aggregate_scores') }}">Aggregate Scores</a></td>
-            <td>
-                A break down of general statistics of all total scores and a
-                break down of the number of times a total score has been
-                achieved.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('panelist_appearances_by_year') }}">Appearances by Year</a></td>
-            <td>
-                A pivot table containing a list of panelists and the number of
-                appearances each panelist has made, broken out by year
-                (excluding Best Of and Repeat shows).
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('panelist_bluff_stats') }}">Bluff the Listener Statistics</a></td>
-            <td>
-                A report providing a breakdown of the number of times each panelist
-                had their Bluff the Listener story chosen, had the correct story, and
-                the number of appearances on shows that had a Bluff the Listener segment.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('panelist_panel_gender_mix') }}">Panel Gender Mix</a></td>
-            <td>
-                A break down of the panel gender mix for each show by year
-                (excluding Best Of, Repeat and special shows).
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('panelist_pvp_report') }}">Panelist vs Panelist</a></td>
-            <td>
-                A break down of how well each panelist has performed against
-                other panelists based on the ranking on each show.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('panelist_first_most_recent_appearances') }}">First and Most Recent Appearances</a></td>
-            <td>
-                A report providing a list of the first and most recent
-                appearances, for both regular and all shows, for each panelist.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('panelist_gender_stats') }}">Statistics by Gender</a></td>
-            <td>
-                A break down of how well all panelists have done by gender
-                and by year.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('panelist_losing_streaks') }}">Losing Streaks</a></td>
-            <td>
-                A listing of the longest losing streak for each panelist.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('panelist_rankings_summary') }}">Rankings Summary</a></td>
-            <td>
-                A break down of the ranking statistics for all panelists.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('panelist_single_appearance') }}">Single Appearance</a></td>
-            <td>
-                A list of panelists that have made only one appearance on the
-                show, excluding any Best Of and Repeat shows.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('panelist_stats_summary') }}">Statistics Summary</a></td>
-            <td>
-                A break down of statistics for all panelists.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('panelist_win_streaks') }}">Win Streaks</a></td>
-            <td>
-                A listing of the longest outright win streak and the longest
-                win streak that includes both outright wins and draws for each
-                panelist.
-            </td>
-        </tr>
-    </tbody>
-</table>
-<!-- Start Panelist Reports -->
+<section id="panelist">
+<h2>Panelist</h2>
+{% include "panelist/_reports.html" %}
+</section>
 
-<!-- Start Scorekeeper Reports -->
-<h2 id="scorekeeper">Scorekeeper</h2>
-<table class="pure-table pure-table-bordered">
-    <colgroup>
-        <col class="report-name">
-        <col class="report-description">
-    </colgroup>
-    <thead>
-        <tr>
-            <th>Report</th>
-            <th>Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><a href="{{ url_for('scorekeeper_introductions') }}">Scorekeeper Introductions</a></td>
-            <td>
-                A listing of all of the introductions that Bill Kurtis and
-                other scorekeepers have used when introducing themselves at the
-                start of each show.
-            </td>
-        </tr>
-    </tbody>
-</table>
-<!-- End Scorekeeper Reports-->
+<section id="scorekeeper">
+<h2>Scorekeeper</h2>
+{% include "scorekeeper/_reports.html" %}
+</section>
 
-<!-- Start Show Reports -->
-<h2 id="show">Show</h2>
-<table class="pure-table pure-table-bordered">
-    <colgroup>
-        <col class="report-name">
-        <col class="report-description">
-    </colgroup>
-    <thead>
-        <tr>
-            <th>Report</th>
-            <th>Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><a href="{{ url_for('show_all_shows') }}">All Shows</a></td>
-            <td>
-                A listing of all shows that have been broadcasted, including
-                Best Ofs and Repeats. The list does not include pledge specials
-                or special shows that were not aired in their original form.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('show_all_women_panel') }}">All Women Panel</a></td>
-            <td>
-                A listing of all shows that have had an all women panel.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('show_guest_hosts') }}">Guest Hosts</a></td>
-            <td>
-                A listing of all shows, including Best Of and repeats, that had
-                a guest host filling in.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('show_high_scoring') }}">High Scoring Shows</a></td>
-            <td>
-                A listing of shows in which the panel total score is greater
-                than or equal to 50.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('show_guest_scorekeepers') }}">Guest Scorekeepers</a></td>
-            <td>
-                A listing of all shows, including Best Of and repeats, that had
-                a guest scorekeeper filling in.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('show_lightning_round_end_three_way_tie') }}">Lightning
-                Round Ending in a Three-Way Tie</a></td>
-            <td>
-                A list of shows in which all three panelists finishing the
-                Lightning Fill-in-the Blank round in a three-way tie.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('show_lightning_round_start_three_way_tie') }}">Lightning
-                Round Starting in a Three-Way Tie</a>
-            </td>
-            <td>
-                A list of shows in which all three panelists starting the
-                Lightning Fill-in-the Blank round in a three-way tie.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('show_lightning_round_start_zero') }}">Lightning
-                Round Starting with Zero Points</a>
-            </td>
-            <td>
-                A list of shows in which panelists start the Lightning
-                Fill-in-the-Blank round with zero points.
-            </td>
-        </tr>
-        <tr>
-            <td><a href="{{ url_for('show_original_shows') }}">Original Shows</a></td>
-            <td>
-                A listing of each original broadcast show, which excludes: Best
-                Of, Repeats, pledge specials and other special shows that were
-                not broadcast in their entirety.
-            </td>
-        </tr>
-    </tbody>
-</table>
-<!-- End Show Reports -->
-{% endblock %}
+<section id="show">
+<h2>Show</h2>
+{% include "show/_reports.html" %}
+</section>
+
+{% endblock content %}

--- a/templates/location/_reports.html
+++ b/templates/location/_reports.html
@@ -1,0 +1,11 @@
+<dl>
+    <dt>
+        <a href="{{ url_for('location_average_scores') }}">Average Scores by Location</a>
+    </dt>
+    <dd>
+        A listing of the average panelist score and average total score for
+        each location the show has broadcasted from. The exception is the 25th
+        Anniversary Special that aired on October 27, 2018 due to the unique
+        Lightning Fill-in-the-Blank format used.
+    </dd>
+</dl>

--- a/templates/location/average_scores.html
+++ b/templates/location/average_scores.html
@@ -1,19 +1,30 @@
 {% extends "base.html" %}
-{% block css %}location/average_scores.css{% endblock %}
-{% block title %}Average Score by Location{% endblock %}
-{% block header_title %}Average Score by Location Report{% endblock %}
+{% block title %}Average Score by Location | Location{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/location/average_scores.css') }}">
+{% endblock head %}
+
 {% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_guest') }}">Guest</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Average Score by Location</h2>
 <p>
     The following table lists the average panelist score and average total
     score for each location the show has broadcasted from. The exception is
     the 25th Anniversary Special that aired on October 27, 2018 due to the
     unique Lightning Fill-in-the-Blank format used.
 </p>
+{% endblock synopsis %}
 
-{% endblock %}
 {% block content %}
 <!-- Start Location Breakdown -->
 <table class="pure-table pure-table-bordered">
@@ -52,4 +63,4 @@
     </tbody>
 </table>
 <!-- End Location Breakdown -->
-{% endblock %}
+{% endblock content %}

--- a/templates/location/average_scores.html
+++ b/templates/location/average_scores.html
@@ -10,7 +10,7 @@
 <div id="breadcrumb">
     <ul>
         <li><a href="{{ url_for('index') }}">Home</a></li>
-        <li><a href="{{ url_for('get_guest') }}">Guest</a></li>
+        <li><a href="{{ url_for('get_location') }}">Location</a></li>
     </ul>
 </div>
 {% endblock breadcrumb %}

--- a/templates/location/index.html
+++ b/templates/location/index.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Location Reports{% endblock %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li>Location</li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
+{% block synopsis %}
+<h2>Location Reports</h2>
+{% endblock synopsis %}
+
+{% block content %}
+{% include "location/_reports.html" %}
+{% endblock content %}

--- a/templates/panelist/_reports.html
+++ b/templates/panelist/_reports.html
@@ -1,0 +1,94 @@
+<dl>
+    <dt>
+        <a href="{{ url_for('panelist_aggregate_scores') }}">Aggregate Scores</a>
+    </dt>
+    <dd>
+        A break down of general statistics of all total scores and a break down
+        of the number of times a total score has been achieved.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('panelist_appearances_by_year') }}">Appearances by Year</a>
+    </dt>
+    <dd>
+        A pivot table containing a list of panelists and the number of appearances
+        each panelist has made, broken out by year (excluding Best Of and Repeat shows).
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('panelist_bluff_stats') }}">Bluff the Listener Statistics</a>
+    </dt>
+    <dd>
+        A report providing a breakdown of the number of times each panelist had
+        their Bluff the Listener story chosen, had the correct story, and the
+        number of appearances on shows that had a Bluff the Listener segment.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('panelist_first_most_recent_appearances') }}">First and Most Recent Appearances</a>
+    </dt>
+    <dd>
+        A report providing a list of the first and most recent appearances, for
+        both regular and all shows, for each panelist.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('panelist_panel_gender_mix') }}">Panel Gender Mix</a>
+    </dt>
+    <dd>
+        A break down of the panel gender mix for each show by year (excluding
+        Best Ofs, Repeat and special shows).
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('panelist_pvp_report') }}">Panelist vs Panelist</a>
+    </dt>
+    <dd>
+        A break down of how well each panelist has performed against other
+        panelists based on the ranking on each show.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('panelist_gender_stats') }}">Statistics by Gender</a>
+    </dt>
+    <dd>
+        A break down of how well all panelists have done by gender and by year.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('panelist_losing_streaks') }}">Losing Streaks</a>
+    </dt>
+    <dd>
+        A listing of the longest losing streak for each panelist.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('panelist_rankings_summary') }}">Rankings Summary</a>
+    </dt>
+    <dd>
+        A break down of the ranking statistics for all panelists.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('panelist_single_appearance') }}">Single Appearance</a>
+    </dt>
+    <dd>
+        A list of panelists that have made only one appearance on the show,
+        excluding any Best Of and Repeat shows.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('panelist_stats_summary') }}">Statistics Summary</a>
+    </dt>
+    <dd>
+        A break down of statistics for all panelists.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('panelist_win_streaks') }}">Win Streaks</a>
+    </dt>
+    <dd>
+        A listing of the longest outright win streak and the longest win streak
+        that includes both outright wins and draws for each panelist.
+    </dd>
+</dl>

--- a/templates/panelist/aggregate_scores.html
+++ b/templates/panelist/aggregate_scores.html
@@ -1,20 +1,32 @@
 {% extends "base.html" %}
-{% block css %}panelist/aggregate_scores.css{% endblock %}
-{% block title %}Panelist Aggregate Scores{% endblock %}
-{% block header_title %}Panelist Aggregate Scores Report{% endblock %}
+{% block title %}Aggregate Scores | Panelist{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/panelist/aggregate_scores.css') }}">
+{% endblock head %}
+
 {% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_panelist') }}">Panelist</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Aggregate Scores</h2>
 <p>
     The first table details the general statistics for entire aggregate of
     panelist total scores. The second table breaks down the number of instances
     a total score has been achieved at the end of the show.
 </p>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Aggregate Score Statistics Section -->
-<h2 id="panelist">Aggregate Score Statistics</h2>
+<h3 id="panelist">Aggregate Score Statistics</h3>
 <table class="pure-table pure-table-bordered">
     <colgroup>
         <col class="score-stat">
@@ -60,7 +72,7 @@
 <!-- End Aggregate Score Statistics Section -->
 
 <!-- Start Score Spread Section -->
-<h2 id="panelist">Aggregate Score Spread</h2>
+<h3 id="panelist">Aggregate Score Spread</h3>
 <table class="pure-table pure-table-bordered">
     <colgroup>
         <col class="spread-score">
@@ -82,4 +94,4 @@
     </tbody>
 </table>
 <!-- End Score Spread Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/panelist/appearances_by_year.html
+++ b/templates/panelist/appearances_by_year.html
@@ -1,17 +1,29 @@
 {% extends "base.html" %}
-{% block css %}panelist/appearances_by_year.css{% endblock %}
-{% block title %}Panelist Appearances by Year{% endblock %}
-{% block header_title %}Panelist Appearances by Year Report{% endblock %}
+{% block title %}Appearances by Year | Panelist{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/panelist/appearances_by_year.css') }}">
+{% endblock head %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_panelist') }}">Panelist</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Appearances by Year</h2>
 <p>
     The pivot table below contains a list of panelists and the number of
     appearances each panelist has made, broken out by year (excluding
     Best Of and Repeat shows).
 </p>
-{% endblock %}
-{% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Appearances by Year Section -->
 <div id="results">
@@ -61,4 +73,4 @@
 </table>
 </div>
 <!-- End Appearances by Year Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/panelist/bluff_stats.html
+++ b/templates/panelist/bluff_stats.html
@@ -1,8 +1,22 @@
 {% extends "base.html" %}
-{% block css %}panelist/bluff_stats.css{% endblock %}
-{% block title %}Panelist Bluff the Listener Statistics Report{% endblock %}
-{% block header_title %}Panelist Bluff the Listener Statistics Report{% endblock %}
+{% block title %}Bluff the Listener Statistics | Panelist{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/panelist/bluff_stats.css') }}">
+{% endblock head %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_panelist') }}">Panelist</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Bluff the Listener Statistics</h2>
 <p>
     This report provides a breakdown of the number of times each panelist
     had their Bluff the Listener story chosen, had the correct story, and
@@ -15,10 +29,8 @@
     panelists that do not appear on this list do not have any Bluff the
     Listener information entered from those shows.
 </p>
-{% endblock %}
-{% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Panelist Bluff the Listener Stats Section -->
 <table class="pure-table pure-table-bordered">
@@ -61,4 +73,4 @@
     </tfoot>
 </table>
 <!-- End Panelist Bluff the Listener Stats Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/panelist/first_most_recent_appearances.html
+++ b/templates/panelist/first_most_recent_appearances.html
@@ -1,16 +1,28 @@
 {% extends "base.html" %}
-{% block css %}panelist/first_most_recent_appearances.css{% endblock %}
-{% block title %}First and Most Recent Appearances | Panelist {% endblock %}
-{% block header_title %}First and Most Recent Appearances Report{% endblock %}
+{% block title %}First and Most Recent Appearances | Panelist{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/panelist/first_most_recent_appearances.css') }}">
+{% endblock head %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_panelist') }}">Panelist</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>First and Most Recent Appearances</h2>
 <p>
     This report provides a list of the first and most recent appearances, for
     both regular and all shows, for each panelist.
 </p>
-{% endblock %}
-{% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start First and Most Recent Appearances Section -->
 <table class="pure-table pure-table-bordered">
@@ -67,4 +79,4 @@
     </tbody>
 </table>
 <!-- End First and Most Recent Appearances Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/panelist/gender_mix.html
+++ b/templates/panelist/gender_mix.html
@@ -1,17 +1,29 @@
 {% extends "base.html" %}
-{% block css %}panelist/gender_mix.css{% endblock %}
-{% block title %}Panel Gender Mix{% endblock %}
-{% block header_title %}Panel Gender Mix Report{% endblock %}
+{% block title %}Panel Gender Mix | Panelist{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/panelist/gender_mix.css') }}">
+{% endblock head %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_panelist') }}">Panelist</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Panel Gender Mix</h2>
 <p>
     This report provides a breakdown of the gender mix of panels for all
     broadcasted shows by year, excluding Best Of, Repeats, pledge specials,
     and the 25th Anniversary special.
 </p>
-{% endblock %}
-{% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Panel Mix Breakdown Section -->
 <table class="pure-table pure-table-bordered">
@@ -47,4 +59,4 @@
     </tbody>
 </table>
 <!-- End Panel Mix Breakdown Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/panelist/gender_stats.html
+++ b/templates/panelist/gender_stats.html
@@ -1,15 +1,27 @@
 {% extends "base.html" %}
-{% block css %}panelist/gender_stats.css{% endblock %}
-{% block title %}Statistics by Gender{% endblock %}
-{% block header_title %}Statistics by Gender Report{% endblock %}
+{% block title %}Statistics by Gender | Panelist{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/panelist/gender_stats.css') }}">
+{% endblock head %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_panelist') }}">Panelist</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Statistics by Gender</h2>
 <p>
     This report provides a break down of panelist statistics by gender.
 </p>
-{% endblock %}
-{% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Gender Statistics Breakdown Section -->
 <table class="pure-table pure-table-bordered">
@@ -87,4 +99,4 @@
     </tbody>
 </table>
 <!-- End Gender Statistics Breakdown Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/panelist/index.html
+++ b/templates/panelist/index.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Panelist Reports{% endblock %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li>Panelist</li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
+{% block synopsis %}
+<h2>Panelist Reports</h2>
+{% endblock synopsis %}
+
+{% block content %}
+{% include "panelist/_reports.html" %}
+{% endblock content %}

--- a/templates/panelist/losing_streaks.html
+++ b/templates/panelist/losing_streaks.html
@@ -1,16 +1,28 @@
 {% extends "base.html" %}
-{% block css %}panelist/losing_streaks.css{% endblock %}
-{% block title %}Panelist Losing Streaks{% endblock %}
-{% block header_title %}Panelist Losing Streaks Report{% endblock %}
+{% block title %}Losing Streaks | Panelist{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/panelist/losing_streaks.css') }}">
+{% endblock head %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_panelist') }}">Panelist</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Losing Streaks</h2>
 <p>
     Listing of the longest losing streak for each panelist. All losses is
     defined by not finishing the game in first or tied for first.
 </p>
-{% endblock %}
-{% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Panelist Losing Streaks Section -->
 <table class="pure-table pure-table-bordered">
@@ -92,4 +104,4 @@
     </tfoot>
 </table>
 <!-- Start Panelist Losing Streaks Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/panelist/panelist_vs_panelist.html
+++ b/templates/panelist/panelist_vs_panelist.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Panelist vs Panelist  | Wait Wait Don't Tell Me! Reports</title>
+    <title>Panelist vs Panelist | Panelist | Wait Wait Don't Tell Me! Reports</title>
     <!-- Import Pure CSS Base -->
     <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/pure-min.css">
     <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans&display=swap" rel="stylesheet">

--- a/templates/panelist/rankings_summary.html
+++ b/templates/panelist/rankings_summary.html
@@ -1,16 +1,28 @@
 {% extends "base.html" %}
-{% block css %}panelist/rankings_summary.css{% endblock %}
-{% block title %}Panelist Rankings Summary{% endblock %}
-{% block header_title %}Panelist Rankings Summary Report{% endblock %}
+{% block title %}Rankings Summary | Panelist{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/panelist/rankings_summary.css') }}">
+{% endblock head %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_panelist') }}">Panelist</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Rankings Summary</h2>
 <p>
     This report provides a break down of each panelist's ranking
     statistics.
 </p>
-{% endblock %}
-{% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Panelist Rankings Breakdown Section -->
 <table class="pure-table pure-table-bordered">
@@ -65,4 +77,4 @@
     </tfoot>
 </table>
 <!-- End Panelist Rankings Breakdown Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/panelist/single_appearance.html
+++ b/templates/panelist/single_appearance.html
@@ -1,16 +1,28 @@
 {% extends "base.html" %}
-{% block css %}panelist/single_appearance.css{% endblock %}
-{% block title %}Panelists with Single Appearance{% endblock %}
-{% block header_title %}Panelists with Single Appearance Report{% endblock %}
+{% block title %}Single Appearance | Panelist{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/panelist/single_appearance.css') }}">
+{% endblock head %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_panelist') }}">Panelist</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Single Appearance</h2>
 <p>
     This report lists out the panelists that have made only one appearance
     on the show, excluding any Best Of and Repeat shows.
 </p>
-{% endblock %}
-{% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Panelist Single Appearance Section -->
 <table class="pure-table pure-table-bordered">
@@ -52,4 +64,4 @@
     </tfoot>
 </table>
 <!-- End Panelist Single Appearance Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/panelist/stats_summary.html
+++ b/templates/panelist/stats_summary.html
@@ -1,15 +1,26 @@
 {% extends "base.html" %}
-{% block css %}panelist/stats_summary.css{% endblock %}
-{% block title %}Panelist Statistics Summary{% endblock %}
-{% block header_title %}Panelist Statistics Summary Report{% endblock %}
+{% block title %}Statistics Summary | Panelist{% endblock %}
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/panelist/stats_summary.css') }}">
+{% endblock head %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_panelist') }}">Panelist</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Statistics Summary</h2>
 <p>
     This report provides a break down of statistics by panelist.
 </p>
-{% endblock %}
-{% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Panelist Statistics Breakdown Section -->
 <table class="pure-table pure-table-bordered">
@@ -90,4 +101,4 @@
     </tfoot>
 </table>
 <!-- End Panelist Statistics Breakdown Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/panelist/win_streaks.html
+++ b/templates/panelist/win_streaks.html
@@ -1,16 +1,28 @@
 {% extends "base.html" %}
-{% block css %}panelist/win_streaks.css{% endblock %}
-{% block title %}Panelist Win Streaks{% endblock %}
-{% block header_title %}Panelist Win Streaks Report{% endblock %}
+{% block title %}Win Streaks | Panelist{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/panelist/win_streaks.css') }}">
+{% endblock head %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_panelist') }}">Panelist</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Win Streaks</h2>
 <p>
     Listing of the longest outright win streak and the longest win streak that
     includes both outright wins and draws for each panelist.
 </p>
-{% endblock %}
-{% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Panelist Win Streaks Section -->
 <table class="pure-table pure-table-bordered">
@@ -92,4 +104,4 @@
     </tfoot>
 </table>
 <!-- Start Panelist Win Streaks Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/scorekeeper/_reports.html
+++ b/templates/scorekeeper/_reports.html
@@ -1,0 +1,9 @@
+<dl>
+    <dt>
+        <a href="{{ url_for('scorekeeper_introductions') }}">Introductions</a>
+    </dt>
+    <dd>
+        A listing of all of the introductions that Bill Kurtis and other
+        scorekeepers have used when introducing themselves at the start of each show.
+    </dd>
+</dl>

--- a/templates/scorekeeper/index.html
+++ b/templates/scorekeeper/index.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Scorekeeper Reports{% endblock %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li>Scorekeeper</li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
+{% block synopsis %}
+<h2>Scorekeeper Reports</h2>
+{% endblock synopsis %}
+
+{% block content %}
+{% include "scorekeeper/_reports.html" %}
+{% endblock content %}

--- a/templates/scorekeeper/introductions.html
+++ b/templates/scorekeeper/introductions.html
@@ -1,18 +1,30 @@
 {% extends "base.html" %}
-{% block css %}scorekeeper/introductions.css{% endblock %}
-{% block title %}Scorekeeper Introductions{% endblock %}
-{% block header_title %}Scorekeeper Introductions{% endblock %}
+{% block title %}Introductions | Scorekeeper{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/scorekeeper/introductions.css') }}">
+{% endblock head %}
+
 {% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_scorekeeper') }}">Scorekeeper</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Introductions</h2>
 <p>
     Listing of all of the introductions that Bill Kurtis and other scorekeepers
     have used when introducing themselves at the start of each show.
 </p>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
-<h2>Scorekeepers</h2>
+<h3>Scorekeepers</h3>
 <ul>
 {% for scorekeeper in scorekeepers %}
     <li><a href="#{{ scorekeeper.slug }}">{{ scorekeeper.name }}</a></li>
@@ -21,7 +33,7 @@
 
 <!-- Start Scorekeeper Introductions Section -->
 {% for scorekeeper in scorekeepers %}
-<h2 id="{{ scorekeeper.slug }}">{{ scorekeeper.name }}</h2>
+<h3 id="{{ scorekeeper.slug }}">{{ scorekeeper.name }}</h3>
 <table class="pure-table pure-table-bordered">
     <colgroup>
         <col class="show-date">
@@ -58,4 +70,4 @@
 </table>
 {% endfor %}
 <!-- End Scorekeeper Introductions Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/show/_reports.html
+++ b/templates/show/_reports.html
@@ -1,0 +1,79 @@
+<dl>
+    <dt>
+        <a href="{{ url_for('show_all_shows') }}">All Shows</a>
+    </dt>
+    <dd>
+        A listing of all shows that have been broadcasted, including Best Ofs
+        and Repeats. The list does not include pledge specials or special shows
+        that were not aired in their original form.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('show_all_women_panel') }}">All Women Panel</a>
+    </dt>
+    <dd>
+        A listing of all shows that have had an all women panel.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('show_high_scoring') }}">High Scoring Shows</a>
+    </dt>
+    <dd>
+        A listing of shows in which the panel total score is greater than or
+        equal to 50.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('show_lightning_round_end_three_way_tie') }}">Lightning
+        Round Ending in a Three-Way Tie</a>
+    </dt>
+    <dd>
+        A list of shows in which all three panelists finishing the Lightning
+        Fill-in-the Blank round in a three-way tie.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('show_lightning_round_start_three_way_tie') }}">Lightning
+        Round Starting in a Three-Way Tie</a>
+    </dt>
+    <dd>
+        A list of shows in which all three panelists starting the Lightning
+        Fill-in-the Blank round in a three-way tie.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('show_lightning_round_start_zero') }}">Lightning
+        Round Starting with Zero Points</a>
+    </td>
+    <dd>
+        A list of shows in which panelists start the Lightning Fill-in-the-Blank
+        round with zero points.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('show_original_shows') }}">Original Shows</a>
+    </td>
+    <dd>
+        A listing of each original broadcast show, which excludes: Best Ofs,
+        Repeats, pledge specials and other special shows that were not broadcast
+        in their entirety.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('show_guest_hosts') }}">Shows with Guest Host</a>
+    </dt>
+    <dd>
+        A listing of all shows, including Best Of and repeats, that had a guest
+        host filling in.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('show_guest_scorekeepers') }}">Shows with Guest
+        Scorekeeper</a>
+    </dt>
+    <dd>
+        A listing of all shows, including Best Of and repeats, that had a
+        guest scorekeeper filling in.
+    </dd>
+
+</dl>

--- a/templates/show/all_shows.html
+++ b/templates/show/all_shows.html
@@ -1,17 +1,29 @@
 {% extends "base.html" %}
-{% block css %}show/shows.css{% endblock %}
-{% block title %}All Shows{% endblock %}
-{% block header_title %}All Shows Report{% endblock %}
+{% block title %}All Shows | Show{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/show/shows.css') }}">
+{% endblock head %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_show') }}">Show</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>All Shows</h2>
 <p>
     Listing of all shows that have been broadcasted, including Best Ofs and
     Repeats. The list does not include pledge specials or special shows that
     were not aired in their original form.
 </p>
-{% endblock %}
-{% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Original Show Listing -->
 <p>
@@ -101,4 +113,4 @@
     </tfoot>
 </table>
 <!-- End Original Show Listing -->
-{% endblock %}
+{% endblock content %}

--- a/templates/show/all_women_panel.html
+++ b/templates/show/all_women_panel.html
@@ -1,15 +1,27 @@
 {% extends "base.html" %}
-{% block css %}show/all_women_panel.css{% endblock %}
-{% block title %}All Women Panel{% endblock %}
-{% block header_title %}All Women Panel{% endblock %}
+{% block title %}All Women Panel | Show{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/show/all_women_panel.css') }}">
+{% endblock head %}
+
 {% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_show') }}">Show</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>All Women Panel</h2>
 <p>
     List of shows that have had an all women panel.
 </p>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start All Women Panel Section -->
 <table class="pure-table pure-table-bordered">
@@ -61,4 +73,4 @@
     </tbody>
 </table>
 <!-- End All Women Panel Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/show/guest_hosts.html
+++ b/templates/show/guest_hosts.html
@@ -1,16 +1,28 @@
 {% extends "base.html" %}
-{% block css %}show/shows.css{% endblock %}
-{% block title %}Shows with Guest Host{% endblock %}
-{% block header_title %}Shows with Guest Host Report{% endblock %}
+{% block title %}Shows with Guest Host | Show{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/show/shows.css') }}">
+{% endblock head %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_show') }}">Show</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Shows with Guest Host</h2>
 <p>
     This report lists all shows, including Best Of and repeats, that had
     a guest host filling in.
 </p>
-{% endblock %}
-{% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Guest Host Shows Listing -->
 <table class="pure-table pure-table-bordered">
@@ -88,4 +100,4 @@
     </tfoot>
 </table>
 <!-- End Guest Host Shows Listing -->
-{% endblock %}
+{% endblock content %}

--- a/templates/show/guest_scorekeepers.html
+++ b/templates/show/guest_scorekeepers.html
@@ -1,16 +1,28 @@
 {% extends "base.html" %}
-{% block css %}show/shows.css{% endblock %}
-{% block title %}Shows with Guest Scorekeeper{% endblock %}
-{% block header_title %}Shows with Guest Scorekeeper Report{% endblock %}
+{% block title %}Shows with Guest Scorekeeper | Show{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/show/shows.css') }}">
+{% endblock head %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_show') }}">Show</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Shows with Guest Scorekeeper</h2>
 <p>
     This report lists all shows, including Best Of and repeats, that had
     a guest scorekeeper filling in.
 </p>
-{% endblock %}
-{% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Guest SCorekeeper Shows Listing -->
 <table class="pure-table pure-table-bordered">
@@ -88,4 +100,4 @@
     </tfoot>
 </table>
 <!-- End Guest Scorekeeper Shows Listing -->
-{% endblock %}
+{% endblock content %}

--- a/templates/show/high_scoring.html
+++ b/templates/show/high_scoring.html
@@ -1,16 +1,28 @@
 {% extends "base.html" %}
-{% block css %}show/high_scoring.css{% endblock %}
-{% block title %}High Scoring Shows{% endblock %}
-{% block header_title %}High Scoring Shows{% endblock %}
+{% block title %}High Scoring Shows | Show{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/show/high_scoring.css') }}">
+{% endblock head %}
+
 {% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_show') }}">Show</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>High Scoring Shows</h2>
 <p>
     List of shows in which the panel total score is greater than or
     equal to 50.
 </p>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start High Scoring Shows Section -->
 <table class="pure-table pure-table-bordered">
@@ -65,4 +77,4 @@
     </tbody>
 </table>
 <!-- End High Scoring Shows Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/show/index.html
+++ b/templates/show/index.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Show Reports{% endblock %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li>Show</li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
+{% block synopsis %}
+<h2>Show Reports</h2>
+{% endblock synopsis %}
+
+{% block content %}
+{% include "show/_reports.html" %}
+{% endblock content %}

--- a/templates/show/lightning_round_end_three_way_tie.html
+++ b/templates/show/lightning_round_end_three_way_tie.html
@@ -1,16 +1,28 @@
 {% extends "base.html" %}
-{% block css %}show/lightning_round_end_three_way_tie.css{% endblock %}
-{% block title %}Lightning Round Ending in a Three-Way Tie{% endblock %}
-{% block header_title %}Lightning Round Ending in a Three-Way Tie{% endblock %}
+{% block title %}Lightning Round Ending in a Three-Way Tie | Show{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/show/lightning_round_end_three_way_tie.css') }}">
+{% endblock head %}
+
 {% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_show') }}">Show</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Lightning Round Ending in a Three-Way Tie</h2>
 <p>
     List of shows in which all three panelists finishing the Lightning
     Fill-in-the Blank round in a three-way tie.
 </p>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Lightning Round Three-Way Tie Section -->
 <table class="pure-table pure-table-bordered">
@@ -50,4 +62,4 @@
     </tfoot>
 </table>
 <!-- End Lightning Round Three-Way Tie Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/show/lightning_round_start_three_way_tie.html
+++ b/templates/show/lightning_round_start_three_way_tie.html
@@ -1,16 +1,28 @@
 {% extends "base.html" %}
-{% block css %}show/lightning_round_start_three_way_tie.css{% endblock %}
-{% block title %}Lightning Round Starting in a Three-Way Tie{% endblock %}
-{% block header_title %}Lightning Round Starting in a Three-Way Tie{% endblock %}
+{% block title %}Lightning Round Starting in a Three-Way Tie | Show{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/show/lightning_round_start_three_way_tie.css') }}">
+{% endblock head %}
+
 {% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_show') }}">Show</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Lightning Round Starting in a Three-Way Tie</h2>
 <p>
     A list of shows in which all three panelists starting the Lightning
     Fill-in-the Blank round in a three-way tie.
 </p>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Lightning Round Three-Way Tie Section -->
 <table class="pure-table pure-table-bordered">
@@ -54,4 +66,4 @@
     </tfoot>
 </table>
 <!-- End Lightning Round Three-Way Tie Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/show/lightning_round_start_zero.html
+++ b/templates/show/lightning_round_start_zero.html
@@ -1,16 +1,28 @@
 {% extends "base.html" %}
-{% block css %}show/lightning_round_start_zero.css{% endblock %}
-{% block title %}Lightning Round Starting with Zero Points{% endblock %}
-{% block header_title %}Lightning Round Starting with Zero Points{% endblock %}
+{% block title %}Lightning Round Starting with Zero Points | Show{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/show/lightning_round_start_zero.css') }}">
+{% endblock head %}
+
 {% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_show') }}">Show</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Lightning Round Starting with Zero Points</h2>
 <p>
     List of shows in which panelists start the Lightning Fill-in-the-Blank
     round with zero points.
 </p>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Lightning Round With Zero Points Section -->
 <table class="pure-table pure-table-bordered">
@@ -56,4 +68,4 @@
     </tfoot>
 </table>
 <!-- End Lightning Round With Zero Points Section -->
-{% endblock %}
+{% endblock content %}

--- a/templates/show/original_shows.html
+++ b/templates/show/original_shows.html
@@ -1,17 +1,29 @@
 {% extends "base.html" %}
-{% block css %}show/shows.css{% endblock %}
-{% block title %}Original Shows{% endblock %}
-{% block header_title %}Original Shows Report{% endblock %}
+{% block title %}Original Shows | Show{% endblock %}
+
+{% block head %}
+{{ super ()}}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/show/shows.css') }}">
+{% endblock head %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('get_show') }}">Show</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
 {% block synopsis %}
+<h2>Original Shows</h2>
 <p>
     Listing of each original broadcast show, which excludes: Best Of, Repeats,
     pledge specials and other special shows that were not broadcast in their
     entirety.
 </p>
-{% endblock %}
-{% block breadcrumb %}
-<div id="homelink">&lt; <a href="{{ url_for('index') }}">Home</a></div>
-{% endblock %}
+{% endblock synopsis %}
+
 {% block content %}
 <!-- Start Original Show Listing -->
 <p>
@@ -83,4 +95,4 @@
     </tfoot>
 </table>
 <!-- End Original Show Listing -->
-{% endblock %}
+{% endblock content %}


### PR DESCRIPTION
Completely re-worked the base template and report template files to use Jinja2 super blocks and to include more useful page breadcrumbs.

The restructuring also introduces new landing pages for guest, location, panelist, scorekeeper and show level. Also, changed the report lists from using tables to description lists, terms and details. The latter was done to improve mobile experience.