### PR TITLE
Re-work Lightning Round Reports

### DIFF
--- a/app.py
+++ b/app.py
@@ -418,10 +418,10 @@ def show_lightning_round_score_start_redirect():
 def show_lightning_round_start_three_way_tie():
     """Lightning Round Starting in Three-Way Tie Report"""
     database_connection.reconnect()
-    same_start = lightning_round.shows_with_same_lightning_round_start(database_connection)
+    shows = lightning_round.shows_starting_with_three_way_tie(database_connection)
 
     return render_template("/show/lightning_round_start_three_way_tie.html",
-                           same_start=same_start)
+                           shows=shows)
 
 @app.route("/show/lightning_round_start_zero")
 def show_lightning_round_start_zero():

--- a/app.py
+++ b/app.py
@@ -28,7 +28,7 @@ from reports.show import (all_women_panel, guest_hosts, guest_scorekeeper,
                           high_scoring, lightning_round, show_details)
 
 #region Global Constants
-APP_VERSION = "1.8.0"
+APP_VERSION = "1.8.1"
 RANK_MAP = {
     "1": "First",
     "1t": "First Tied",
@@ -413,6 +413,14 @@ def show_lightning_round_end_three_way_tie():
 def show_lightning_round_score_start_redirect():
     """Lightning Round Score Start Redirect"""
     return redirect(url_for("show_lightning_round_start_three_way_tie"), 301)
+
+@app.route("/show/lightning_round_start_end_three_way_tie")
+def show_lightning_round_start_end_three_way_tie():
+    """Lightning Round Starting and Ending in Three-Way Tie Report"""
+    database_connection.reconnect()
+    shows = lightning_round.shows_starting_ending_three_way_tie(database_connection)
+    return render_template("/show/lightning_round_start_end_three_way_tie.html",
+                           shows=shows)
 
 @app.route("/show/lightning_round_start_three_way_tie")
 def show_lightning_round_start_three_way_tie():

--- a/reports/show/lightning_round.py
+++ b/reports/show/lightning_round.py
@@ -150,26 +150,27 @@ def shows_lightning_round_start_zero(database_connection: mysql.connector.connec
 
     return shows
 
-def shows_with_same_lightning_round_start(database_connection: mysql.connector.connect
-                                         ) -> Dict:
+def shows_starting_with_three_way_tie(database_connection: mysql.connector.connect
+                                     ) -> List[Dict]:
     """Return shows in which the Lightning Fill-in-the-Blank round
     started with the same score for all three panelists"""
 
     show_scores = retrieve_all_lightning_round_start(database_connection)
-    shows = OrderedDict()
+    shows = []
 
     for show in show_scores:
         show_id = show_scores[show]["id"]
         show_date = show_scores[show]["date"]
 
         if len(set(show_scores[show]["scores"])) == 1:
-            shows[show_date] = OrderedDict()
-            shows[show_date]["id"] = show_id
-            shows[show_date]["date"] = show_date
-            shows[show_date]["score"] = show_scores[show]["scores"][0]
+            show_info = OrderedDict()
+            show_info["id"] = show_id
+            show_info["date"] = show_date
+            show_info["score"] = show_scores[show]["scores"][0]
             panelists = retrieve_panelists_by_show_id(show_id=show_id,
                                                       database_connection=database_connection)
-            shows[show_date]["panelists"] = panelists
+            show_info["panelists"] = panelists
+            shows.append(show_info)
 
     return shows
 

--- a/reports/show/lightning_round.py
+++ b/reports/show/lightning_round.py
@@ -152,8 +152,8 @@ def shows_lightning_round_start_zero(database_connection: mysql.connector.connec
 
 def shows_starting_with_three_way_tie(database_connection: mysql.connector.connect
                                      ) -> List[Dict]:
-    """Return shows in which the Lightning Fill-in-the-Blank round
-    started with the same score for all three panelists"""
+    """Retrieve all shows in which all three panelists started the
+    Lightning round in a three-way tie"""
 
     show_scores = retrieve_all_lightning_round_start(database_connection)
     shows = []
@@ -176,8 +176,8 @@ def shows_starting_with_three_way_tie(database_connection: mysql.connector.conne
 
 def shows_ending_with_three_way_tie(database_connection: mysql.connector.connect
                                    ) -> List[Dict]:
-    """Retrieve all shows in which all three panelists ended the show
-    in a three-way tie"""
+    """Retrieve all shows in which all three panelists ended the
+    Lightning round in a three-way tie"""
 
     shows = []
     cursor = database_connection.cursor(dictionary=True)

--- a/static/css/show/lightning_round_end_three_way_tie.css
+++ b/static/css/show/lightning_round_end_three_way_tie.css
@@ -1,5 +1,5 @@
 @media all {
-    col.show-date, col.final-score { width: 9rem; }
+    col.show-date, col.show-score { width: 9rem; }
     col.show-panelists { width: 15rem; }
     td.panelist-names ul { list-style: none; margin: 0; padding: 0; }
 }

--- a/static/css/show/lightning_round_start_end_three_way_tie.css
+++ b/static/css/show/lightning_round_start_end_three_way_tie.css
@@ -1,0 +1,5 @@
+@media all {
+    col.show-date, col.final-score { width: 9rem; }
+    col.show-panelists { width: 15rem; }
+    td.panelist-names ul { list-style: none; margin: 0; padding: 0; }
+}

--- a/static/css/show/lightning_round_start_end_three_way_tie.css
+++ b/static/css/show/lightning_round_start_end_three_way_tie.css
@@ -1,5 +1,5 @@
 @media all {
-    col.show-date, col.final-score { width: 9rem; }
+    col.show-date, col.show-score { width: 9rem; }
     col.show-panelists { width: 15rem; }
     td.panelist-names ul { list-style: none; margin: 0; padding: 0; }
 }

--- a/static/css/show/lightning_round_start_three_way_tie.css
+++ b/static/css/show/lightning_round_start_three_way_tie.css
@@ -1,5 +1,5 @@
 @media all {
-    col.show-date, col.starting-score { width: 9rem; }
+    col.show-date, col.show-score { width: 9rem; }
     col.show-panelists { width: 15rem; }
     td.panelist-names ul { list-style: none; margin: 0; padding: 0; }
 }

--- a/templates/core/sitemap.xml
+++ b/templates/core/sitemap.xml
@@ -125,6 +125,10 @@
     <changefreq>weekly</changefreq>
   </url>
   <url>
+    <loc>{{ site_url }}{{ url_for("show_lightning_round_start_end_three_way_tie") }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
     <loc>{{ site_url }}{{ url_for("show_lightning_round_start_three_way_tie") }}</loc>
     <changefreq>weekly</changefreq>
   </url>

--- a/templates/show/_reports.html
+++ b/templates/show/_reports.html
@@ -33,6 +33,15 @@
     </dd>
 
     <dt>
+        <a href="{{ url_for('show_lightning_round_start_end_three_way_tie') }}">Lightning
+        Round Starting and Ending in a Three-Way Tie</a>
+    </dt>
+    <dd>
+        A list of shows in which all three panelists starting and ending the
+        Lightning Fill-in-the Blank round in a three-way tie.
+    </dd>
+
+    <dt>
         <a href="{{ url_for('show_lightning_round_start_three_way_tie') }}">Lightning
         Round Starting in a Three-Way Tie</a>
     </dt>

--- a/templates/show/lightning_round_end_three_way_tie.html
+++ b/templates/show/lightning_round_end_three_way_tie.html
@@ -29,7 +29,7 @@
     <colgroup>
         <col class="show-date">
         <col class="show-panelists">
-        <col class="show-final-score">
+        <col class="show-score">
     </colgroup>
     <thead>
         <tr>

--- a/templates/show/lightning_round_end_three_way_tie.html
+++ b/templates/show/lightning_round_end_three_way_tie.html
@@ -53,6 +53,7 @@
         </tr>
         {% endfor %}
     </tbody>
+    {% if shows|length >= 10 %}
     <tfoot>
         <tr>
             <th scope="col">Show Date</th>
@@ -60,6 +61,7 @@
             <th scope="col">Final Score</th>
         </tr>
     </tfoot>
+    {% endif %}
 </table>
 <!-- End Lightning Round Three-Way Tie Section -->
 {% endblock content %}

--- a/templates/show/lightning_round_start_end_three_way_tie.html
+++ b/templates/show/lightning_round_start_end_three_way_tie.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
-{% block title %}Lightning Round Starting in a Three-Way Tie | Show{% endblock %}
+{% block title %}Lightning Round Starting adn Ending in a Three-Way Tie | Show{% endblock %}
 
 {% block head %}
 {{ super ()}}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/show/lightning_round_start_three_way_tie.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/show/lightning_round_start_end_three_way_tie.css') }}">
 {% endblock head %}
 
 {% block breadcrumb %}
@@ -16,10 +16,10 @@
 {% endblock breadcrumb %}
 
 {% block synopsis %}
-<h2>Lightning Round Starting in a Three-Way Tie</h2>
+<h2>Lightning Round Starting and Ending in a Three-Way Tie</h2>
 <p>
-    A list of shows in which all three panelists starting the Lightning
-    Fill-in-the Blank round in a three-way tie.
+    List of shows in which all three panelists starting and finishing the
+    Lightning Fill-in-the Blank round in a three-way tie.
 </p>
 {% endblock synopsis %}
 
@@ -30,22 +30,22 @@
         <col class="show-date">
         <col class="show-panelists">
         <col class="show-start-score">
+        <col class="show-correct">
+        <col class="show-final-score">
     </colgroup>
     <thead>
         <tr>
             <th scope="col">Show Date</th>
             <th scope="col">Panelists</th>
             <th scope="col">Starting Score</th>
+            <th scope="col">Correct</th>
+            <th scope="col">Final Score</th>
         </tr>
     </thead>
     <tbody>
         {% for show in shows %}
         <tr>
-            <td>
-                <a href="{{ stats_url }}/shows/{{ show.date|replace('-', '/') }}">
-                    {{ show.date }}
-                </a>
-            </td>
+            <td><a href="{{ stats_url }}/shows/{{ show.date|replace('-', '/') }}">{{ show.date }}</a></td>
             <td class="panelist-names">
                 <ul>
                 {% for panelist in show.panelists %}
@@ -53,6 +53,8 @@
                 {% endfor %}
                 </ul>
             </td>
+            <td>{{ show.start }}</td>
+            <td>{{ show.correct }}</td>
             <td>{{ show.score }}</td>
         </tr>
         {% endfor %}
@@ -63,6 +65,8 @@
             <th scope="col">Show Date</th>
             <th scope="col">Panelists</th>
             <th scope="col">Starting Score</th>
+            <th scope="col">Correct</th>
+            <th scope="col">Final Score</th>
         </tr>
     </tfoot>
     {% endif %}

--- a/templates/show/lightning_round_start_end_three_way_tie.html
+++ b/templates/show/lightning_round_start_end_three_way_tie.html
@@ -29,9 +29,9 @@
     <colgroup>
         <col class="show-date">
         <col class="show-panelists">
-        <col class="show-start-score">
-        <col class="show-correct">
-        <col class="show-final-score">
+        <col class="show-score">
+        <col class="show-score">
+        <col class="show-score">
     </colgroup>
     <thead>
         <tr>

--- a/templates/show/lightning_round_start_three_way_tie.html
+++ b/templates/show/lightning_round_start_three_way_tie.html
@@ -39,21 +39,21 @@
         </tr>
     </thead>
     <tbody>
-        {% for show in same_start %}
+        {% for show in shows %}
         <tr>
             <td>
-                <a href="{{ stats_url }}/shows/{{ same_start[show].date|replace('-', '/') }}">
-                    {{ same_start[show].date }}
+                <a href="{{ stats_url }}/shows/{{ show.date|replace('-', '/') }}">
+                    {{ show.date }}
                 </a>
             </td>
             <td class="panelist-names">
                 <ul>
-                {% for panelist in same_start[show].panelists %}
+                {% for panelist in show.panelists %}
                     <li> {{ panelist.name }}</li>
                 {% endfor %}
                 </ul>
             </td>
-            <td>{{ same_start[show].score }}</td>
+            <td>{{ show.score }}</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/templates/show/lightning_round_start_three_way_tie.html
+++ b/templates/show/lightning_round_start_three_way_tie.html
@@ -29,7 +29,7 @@
     <colgroup>
         <col class="show-date">
         <col class="show-panelists">
-        <col class="show-start-score">
+        <col class="show-score">
     </colgroup>
     <thead>
         <tr>


### PR DESCRIPTION
Add a new report that returns a list of shows in which panelists start and end the Lightning round in a three-way tie.

Also, clean-up code and styles across the three three-way tie reports.