### PR TITLE
Use request object available in scope instead of passing in via render_template

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,7 +32,7 @@ from reports.show import (all_women_panel, guest_hosts, guest_scorekeeper,
                           show_details)
 
 #region Global Constants
-APP_VERSION = "1.10.0"
+APP_VERSION = "1.10.1"
 RANK_MAP = {
     "1": "First",
     "1t": "First Tied",
@@ -542,22 +542,16 @@ def show_search_multiple_panelists():
                                                           repeats)
 
             return render_template("/show/search_multiple_panelists.html",
-                                   request_type=request.method,
-                                   form_data=request.form,
                                    panelists=panelists,
                                    shows=shows)
 
         # Fallback for no valid panelist(s) selected
         return render_template("/show/search_multiple_panelists.html",
-                               request_type=request.method,
-                               form_data=request.form,
                                panelists=panelists,
                                shows=None)
 
     # Fallback for GET request
     return render_template("/show/search_multiple_panelists.html",
-                           request_type=request.method,
-                           form_data=request.form,
                            panelists=panelists,
                            shows=None)
 

--- a/templates/show/search_multiple_panelists.html
+++ b/templates/show/search_multiple_panelists.html
@@ -37,7 +37,7 @@
             <select id="panelist-1" name="panelist_1">
                 <option value="">-- Please chose a panelist --</option>
                 {% for panelist in panelists %}
-                {% if form_data.panelist_1 == panelist %}
+                {% if request.form.panelist_1 == panelist %}
                 <option value="{{ panelist }}" selected>{{ panelists[panelist] }}</option>
                 {% else %}
                 <option value="{{ panelist }}">{{ panelists[panelist] }}</option>
@@ -50,7 +50,7 @@
             <select id="panelist-2" name="panelist_2">
                 <option value="">-- Please chose a panelist --</option>
                 {% for panelist in panelists %}
-                {% if form_data.panelist_2 == panelist %}
+                {% if request.form.panelist_2 == panelist %}
                 <option value="{{ panelist }}" selected>{{ panelists[panelist] }}</option>
                 {% else %}
                 <option value="{{ panelist }}">{{ panelists[panelist] }}</option>
@@ -63,7 +63,7 @@
             <select id="panelist-3" name="panelist_3">
                 <option value="">-- Please chose a panelist --</option>
                 {% for panelist in panelists %}
-                {% if form_data.panelist_3 == panelist %}
+                {% if request.form.panelist_3 == panelist %}
                 <option value="{{ panelist }}" selected>{{ panelists[panelist] }}</option>
                 {% else %}
                 <option value="{{ panelist }}">{{ panelists[panelist] }}</option>
@@ -74,7 +74,7 @@
         <div class="panelist-options">
             <div class="panelist-option">
                 <label for="best-of">Include Best Ofs</label>
-                {% if form_data.best_of %}
+                {% if request.form.best_of %}
                 <input type="checkbox" id="best-of" name="best_of" checked>
                 {% else %}
                 <input type="checkbox" id="best-of" name="best_of">
@@ -82,7 +82,7 @@
             </div>
             <div class="panelist-option">
                 <label for="repeats">Include Repeats</label>
-                {% if form_data.repeats %}
+                {% if request.form.repeats %}
                 <input type="checkbox" id="repeats" name="repeats" checked>
                 {% else %}
                 <input type="checkbox" id="repeats" name="repeats">
@@ -93,9 +93,9 @@
     </fieldset>
 </form>
 
-{% if request_type == "POST" %}
+{% if request.method == "POST" %}
 <hr>
-{% if not form_data.panelist_1 and not form_data.panelist_2 and not form_data.panelist_3 %}
+{% if not request.form.panelist_1 and not request.panelist_2 and not request.form.panelist_3 %}
 <p class="result-message">No panelists were selected.</p>
 {% elif not shows %}
 <p class="result-message">No results returned.</p>


### PR DESCRIPTION
Flask already makes the request object available for use within templates instead of having to pass in values via render_template(). Updating the "Search Shows by Multiple Panelists" report view to make use of the request object directly.