### PR TITLE
Add link rel=canonical and Clean-up Search Shows by Multiple Panelists

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,7 +32,7 @@ from reports.show import (all_women_panel, guest_hosts, guest_scorekeeper,
                           show_details)
 
 #region Global Constants
-APP_VERSION = "1.10.0"
+APP_VERSION = "1.10.1"
 RANK_MAP = {
     "1": "First",
     "1t": "First Tied",
@@ -542,22 +542,16 @@ def show_search_multiple_panelists():
                                                           repeats)
 
             return render_template("/show/search_multiple_panelists.html",
-                                   request_type=request.method,
-                                   form_data=request.form,
                                    panelists=panelists,
                                    shows=shows)
 
         # Fallback for no valid panelist(s) selected
         return render_template("/show/search_multiple_panelists.html",
-                               request_type=request.method,
-                               form_data=request.form,
                                panelists=panelists,
                                shows=None)
 
     # Fallback for GET request
     return render_template("/show/search_multiple_panelists.html",
-                           request_type=request.method,
-                           form_data=request.form,
                            panelists=panelists,
                            shows=None)
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,9 @@
     <link rel="stylesheet" href="https://unpkg.com/purecss@2.0.3/build/pure-min.css" integrity="sha384-cg6SkqEOCV1NbJoCu11+bm0NvBRc8IYLRGXkmNrqUBfTjmMYwNKPWBTIKyw9mHNJ" crossorigin="anonymous">
     <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:400,500,600,700%7CIBM+Plex+Mono:400,500,600,700&display=swap" rel="stylesheet">
     <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
-
+    {% if site_url and request.path %}
+    <link rel="canonical" href="{{ site_url}}{{ request.path }}">
+    {% endif %}
     <!-- Import Custom CSS -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 

--- a/templates/show/search_multiple_panelists.html
+++ b/templates/show/search_multiple_panelists.html
@@ -95,7 +95,7 @@
 
 {% if request.method == "POST" %}
 <hr>
-{% if not request.form.panelist_1 and not request.panelist_2 and not request.form.panelist_3 %}
+{% if not request.form.panelist_1 and not request.form.panelist_2 and not request.form.panelist_3 %}
 <p class="result-message">No panelists were selected.</p>
 {% elif not shows %}
 <p class="result-message">No results returned.</p>

--- a/templates/show/search_multiple_panelists.html
+++ b/templates/show/search_multiple_panelists.html
@@ -37,7 +37,7 @@
             <select id="panelist-1" name="panelist_1">
                 <option value="">-- Please chose a panelist --</option>
                 {% for panelist in panelists %}
-                {% if form_data.panelist_1 == panelist %}
+                {% if request.form.panelist_1 == panelist %}
                 <option value="{{ panelist }}" selected>{{ panelists[panelist] }}</option>
                 {% else %}
                 <option value="{{ panelist }}">{{ panelists[panelist] }}</option>
@@ -50,7 +50,7 @@
             <select id="panelist-2" name="panelist_2">
                 <option value="">-- Please chose a panelist --</option>
                 {% for panelist in panelists %}
-                {% if form_data.panelist_2 == panelist %}
+                {% if request.form.panelist_2 == panelist %}
                 <option value="{{ panelist }}" selected>{{ panelists[panelist] }}</option>
                 {% else %}
                 <option value="{{ panelist }}">{{ panelists[panelist] }}</option>
@@ -63,7 +63,7 @@
             <select id="panelist-3" name="panelist_3">
                 <option value="">-- Please chose a panelist --</option>
                 {% for panelist in panelists %}
-                {% if form_data.panelist_3 == panelist %}
+                {% if request.form.panelist_3 == panelist %}
                 <option value="{{ panelist }}" selected>{{ panelists[panelist] }}</option>
                 {% else %}
                 <option value="{{ panelist }}">{{ panelists[panelist] }}</option>
@@ -74,7 +74,7 @@
         <div class="panelist-options">
             <div class="panelist-option">
                 <label for="best-of">Include Best Ofs</label>
-                {% if form_data.best_of %}
+                {% if request.form.best_of %}
                 <input type="checkbox" id="best-of" name="best_of" checked>
                 {% else %}
                 <input type="checkbox" id="best-of" name="best_of">
@@ -82,7 +82,7 @@
             </div>
             <div class="panelist-option">
                 <label for="repeats">Include Repeats</label>
-                {% if form_data.repeats %}
+                {% if request.form.repeats %}
                 <input type="checkbox" id="repeats" name="repeats" checked>
                 {% else %}
                 <input type="checkbox" id="repeats" name="repeats">
@@ -93,9 +93,9 @@
     </fieldset>
 </form>
 
-{% if request_type == "POST" %}
+{% if request.method == "POST" %}
 <hr>
-{% if not form_data.panelist_1 and not form_data.panelist_2 and not form_data.panelist_3 %}
+{% if not request.form.panelist_1 and not request.panelist_2 and not request.form.panelist_3 %}
 <p class="result-message">No panelists were selected.</p>
 {% elif not shows %}
 <p class="result-message">No results returned.</p>


### PR DESCRIPTION
Adding in link rel=canonical to the header in the base template to reduce duplicate links in search engine results.

Make use of the available request object in templates instead of passing in values via render_template()