### PR TITLE
Correct handling of no panelist or guest score

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,7 +43,7 @@ from reports.show import (all_women_panel,
                           show_details)
 
 #region Global Constants
-APP_VERSION = "1.13.0"
+APP_VERSION = "1.13.1"
 RANK_MAP = {
     "1": "First",
     "1t": "First Tied",

--- a/templates/show/all_women_panel.html
+++ b/templates/show/all_women_panel.html
@@ -61,12 +61,22 @@
             <td class="panelist-names">
                 <ul>
                 {% for panelist in show.panelists %}
-                    <li>{{ panelist.name }}: {{ panelist.score }}</li>
+                    <li>
+                    {% if show.guest.score %}
+                    {{ panelist.name }}: {{ panelist.score }}
+                    {% else %}
+                    {{ panelist.name }}
+                    {% endif %}    
+                    </li>
                 {% endfor %}
                 </ul>
             </td>
             <td>
+                {% if show.guest.score %}
                 {{ show.guest.name }}: {{ show.guest.score }}
+                {% else %}
+                {{ show.guest.name }}
+                {% endif %}
                 {% if show.guest.exception %}
                 *
                 {% endif %}


### PR DESCRIPTION
The "All Women Panel" report will display "None" when panelist and/or guest score isn't set in the database. Add a check and only display the score IFF there is a score.