### PR TITLE
Remove extra column from Panelist Stats Summary colgroup

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,7 +43,7 @@ from reports.show import (all_women_panel,
                           show_details)
 
 #region Global Constants
-APP_VERSION = "1.13.1"
+APP_VERSION = "1.13.2"
 RANK_MAP = {
     "1": "First",
     "1t": "First Tied",

--- a/templates/panelist/stats_summary.html
+++ b/templates/panelist/stats_summary.html
@@ -35,7 +35,6 @@
         <col class="panelist-scores">
         <col class="panelist-scores">
         <col class="panelist-scores">
-        <col class="panelist-scores">
     </colgroup>
     <thead>
         <tr>


### PR DESCRIPTION
Removing an extra column that was added in the table's colgroup