### PR TITLE
Adding show date filter to query and adding table footer

### DIFF
--- a/reports/show/show_counts.py
+++ b/reports/show/show_counts.py
@@ -33,16 +33,16 @@ def retrieve_show_counts_by_year(database_connection: mysql.connector.connect
         cursor = database_connection.cursor(dictionary=True)
         query = ("SELECT "
                  "(SELECT COUNT(showid) FROM ww_shows "
-                 " WHERE YEAR(showdate) = %s "
+                 " WHERE YEAR(showdate) = %s AND showdate <= NOW() "
                  " AND bestof = 0 AND repeatshowid IS NULL) AS 'regular', "
                  "(SELECT COUNT(showid) FROM ww_shows "
-                 " WHERE YEAR(showdate) = %s "
+                 " WHERE YEAR(showdate) = %s AND showdate <= NOW() "
                  " AND bestof = 1 AND repeatshowid IS NULL) AS 'bestof', "
                  "(SELECT COUNT(showid) FROM ww_shows "
-                 " WHERE YEAR(showdate) = %s "
+                 " WHERE YEAR(showdate) = %s AND showdate <= NOW() "
                  " AND bestof = 0 AND repeatshowid IS NOT NULL) AS 'repeat', "
                  "(SELECT COUNT(showid) FROM ww_shows "
-                 " WHERE YEAR(showdate) = %s "
+                 " WHERE YEAR(showdate) = %s AND showdate <= NOW() "
                  " AND bestof = 1 AND repeatshowid IS NOT NULL) AS 'repeat_bestof';")
         cursor.execute(query, (year, year, year, year, ))
         result = cursor.fetchone()

--- a/templates/show/show_counts_by_year.html
+++ b/templates/show/show_counts_by_year.html
@@ -21,6 +21,10 @@
     This report provides a count of the number of regular, Best Of, repeat, and
     repeat Best Of shows on a per-year basis.
 </p>
+<p>
+    Show counts for the current year will only include shows that have aired on
+    or before the current date.
+</p>
 {% endblock synopsis %}
 
 {% block content %}
@@ -56,6 +60,16 @@
         </tr>
         {% endfor %}
     </tbody>
+    <tfoot>
+        <tr>
+            <th scope="col">Year</th>
+            <th scope="col">Regular Shows</th>
+            <th scope="col">Best Ofs</th>
+            <th scope="col">Repeats</th>
+            <th scope="col">Best Of Repeats</th>
+            <th scope="col">Total</th>
+        </tr>
+    </tfoot>
 </table>
 <!-- End Show Counts by Year Section -->
 {% endblock content %}


### PR DESCRIPTION
Adding a date filter on the queries to limit to `showdate` to be less than or equal to the current date to exclude future shows from appear in the counts. Also, adding table footer.