### PR TITLE
Adding panelist appearance counts to First and Most Recent Appearances Report

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig File
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{json,md,py,rst}]
+charset = utf-8
+
+[*.{css,html,json,py,rst,tmpl}]
+indent_size = 4
+indent_style = space

--- a/app.py
+++ b/app.py
@@ -44,7 +44,7 @@ from reports.show import (all_women_panel,
                           show_details)
 
 #region Global Constants
-APP_VERSION = "1.17.0"
+APP_VERSION = "1.18.0"
 RANK_MAP = {
     "1": "First",
     "1t": "First Tied",

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2021 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """Flask application startup file"""
 
 import json

--- a/reports/__init__.py
+++ b/reports/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """Explicitly listing all reporting modules"""
 
 from reports.guest import (best_of_only,

--- a/reports/guest/__init__.py
+++ b/reports/guest/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """Explicitly listing all guest reporting modules"""
 
 from reports.guest import best_of_only, most_appearances, scores

--- a/reports/guest/best_of_only.py
+++ b/reports/guest/best_of_only.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Guest Best Of Only Appearances Report Functions"""
 
 from collections import OrderedDict

--- a/reports/guest/most_appearances.py
+++ b/reports/guest/most_appearances.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Guest Most Appearances Report Functions"""
 
 from collections import OrderedDict

--- a/reports/guest/scores.py
+++ b/reports/guest/scores.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Guest Scores Report Functions"""
 
 from collections import OrderedDict

--- a/reports/host/__init__.py
+++ b/reports/host/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """Explicitly listing all host reporting modules"""
 
 from reports.host import appearances

--- a/reports/host/appearances.py
+++ b/reports/host/appearances.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Host Appearances Report Functions"""
 
 from collections import OrderedDict

--- a/reports/location/__init__.py
+++ b/reports/location/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """Explicitly listing all location reporting modules"""
 
 from reports.location import average_scores

--- a/reports/location/average_scores.py
+++ b/reports/location/average_scores.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Location Score Breakdown Report Functions"""
 
 from collections import OrderedDict

--- a/reports/panelist/__init__.py
+++ b/reports/panelist/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """Explicitly listing all panelist reporting modules"""
 
 from reports.panelist import (aggregate_scores,

--- a/reports/panelist/aggregate_scores.py
+++ b/reports/panelist/aggregate_scores.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist Aggregate Scores Report Functions"""
 
 from collections import OrderedDict

--- a/reports/panelist/appearances.py
+++ b/reports/panelist/appearances.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist Appearances Report Functions"""
 
 from collections import OrderedDict

--- a/reports/panelist/appearances.py
+++ b/reports/panelist/appearances.py
@@ -53,8 +53,10 @@ def retrieve_first_most_recent_appearances(database_connection: mysql.connector.
         info["slug"] = panelist["slug"]
         info["first"] = None
         info["most_recent"] = None
+        info["count"] = 0
         info["first_all"] = None
         info["most_recent_all"] = None
+        info["count_all"] = 0
         panelist_appearances[panelist["slug"]] = info
 
     cursor = database_connection.cursor(dictionary=True)
@@ -78,6 +80,41 @@ def retrieve_first_most_recent_appearances(database_connection: mysql.connector.
         slug = row["panelistslug"]
         panelist_appearances[slug]["first"] = row["min"].isoformat()
         panelist_appearances[slug]["most_recent"] = row["max"].isoformat()
+
+    query = ("SELECT p.panelist, p.panelistslug, COUNT(pm.panelistid) AS count "
+             "FROM ww_showpnlmap pm "
+             "JOIN ww_shows s ON s.showid = pm.showid "
+             "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
+             "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
+             "AND p.panelist <> '<Multiple>' "
+             "GROUP BY p.panelistid "
+             "ORDER BY p.panelist ASC")
+    cursor.execute(query)
+    result = cursor.fetchall()
+
+    if not result:
+        return None
+
+    for row in result:
+        slug = row["panelistslug"]
+        panelist_appearances[slug]["count"] = row["count"]
+
+    query = ("SELECT p.panelist, p.panelistslug, COUNT(pm.panelistid) AS count "
+             "FROM ww_showpnlmap pm "
+             "JOIN ww_shows s ON s.showid = pm.showid "
+             "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
+             "WHERE p.panelist <> '<Multiple>' "
+             "GROUP BY p.panelistid "
+             "ORDER BY p.panelist ASC")
+    cursor.execute(query)
+    result = cursor.fetchall()
+
+    if not result:
+        return None
+
+    for row in result:
+        slug = row["panelistslug"]
+        panelist_appearances[slug]["count_all"] = row["count"]
 
     query = ("SELECT p.panelist, p.panelistslug, "
              "MIN(s.showdate) AS min, MAX(s.showdate) AS max "

--- a/reports/panelist/appearances_by_year.py
+++ b/reports/panelist/appearances_by_year.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist Apperances by Year Report Functions"""
 
 from collections import OrderedDict

--- a/reports/panelist/bluff_stats.py
+++ b/reports/panelist/bluff_stats.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist Bluff the Listener Statistics Report Functions"""
 
 from collections import OrderedDict

--- a/reports/panelist/debut_by_year.py
+++ b/reports/panelist/debut_by_year.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist Debut by Year Report Functions"""
 
 from collections import OrderedDict

--- a/reports/panelist/gender_mix.py
+++ b/reports/panelist/gender_mix.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panel Gender Mix Report Functions"""
 
 from collections import OrderedDict

--- a/reports/panelist/gender_stats.py
+++ b/reports/panelist/gender_stats.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panel Gender Mix Report Functions"""
 
 from collections import OrderedDict

--- a/reports/panelist/panelist_vs_panelist.py
+++ b/reports/panelist/panelist_vs_panelist.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist vs Panelist Report Functions"""
 
 from collections import OrderedDict

--- a/reports/panelist/panelist_vs_panelist_scoring.py
+++ b/reports/panelist/panelist_vs_panelist_scoring.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist vs Panelist Scoring Report Functions"""
 
 from collections import OrderedDict

--- a/reports/panelist/rankings_summary.py
+++ b/reports/panelist/rankings_summary.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist Rankings Summary Report Functions"""
 
 from collections import OrderedDict

--- a/reports/panelist/single_appearance.py
+++ b/reports/panelist/single_appearance.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist Single Appearance Report Functions"""
 
 from collections import OrderedDict

--- a/reports/panelist/stats_summary.py
+++ b/reports/panelist/stats_summary.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist Statistics Summary Report Functions"""
 
 from collections import OrderedDict

--- a/reports/panelist/streaks.py
+++ b/reports/panelist/streaks.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist Win/Loss Streaks Report Functions"""
 
 from collections import OrderedDict

--- a/reports/scorekeeper/__init__.py
+++ b/reports/scorekeeper/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """Explicitly listing all scorekeeper reporting modules"""
 
 from reports.scorekeeper import (appearances,

--- a/reports/scorekeeper/appearances.py
+++ b/reports/scorekeeper/appearances.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Scorekeeper Appearances Report Functions"""
 
 from collections import OrderedDict

--- a/reports/scorekeeper/introductions.py
+++ b/reports/scorekeeper/introductions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Scorekeeper Introductions Report Functions"""
 
 from collections import OrderedDict

--- a/reports/show/__init__.py
+++ b/reports/show/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """Explicitly listing all show reporting modules"""
 
 from reports.show import (all_women_panel, guest_hosts, guest_scorekeeper,

--- a/reports/show/all_women_panel.py
+++ b/reports/show/all_women_panel.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM All Women Panel Report Functions"""
 
 from collections import OrderedDict

--- a/reports/show/guest_hosts.py
+++ b/reports/show/guest_hosts.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Show Guest Hosts Report Functions"""
 
 from collections import OrderedDict

--- a/reports/show/guest_scorekeeper.py
+++ b/reports/show/guest_scorekeeper.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Show Guest Scorekeeper Report Functions"""
 
 from collections import OrderedDict

--- a/reports/show/lightning_round.py
+++ b/reports/show/lightning_round.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Lightning Round Report Functions"""
 
 from collections import OrderedDict

--- a/reports/show/scoring.py
+++ b/reports/show/scoring.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Show Scoring Reports Functions"""
 
 from collections import OrderedDict

--- a/reports/show/search_multiple_panelists.py
+++ b/reports/show/search_multiple_panelists.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Search Shows by Multiple Selected Panelists Report Functions"""
 
 from collections import OrderedDict

--- a/reports/show/show_counts.py
+++ b/reports/show/show_counts.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2021 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Show Counts Report Functions"""
 
 from collections import OrderedDict

--- a/reports/show/show_details.py
+++ b/reports/show/show_details.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Show Details Report Functions"""
 
 from collections import OrderedDict

--- a/reports/utility.py
+++ b/reports/utility.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """Utility functions used by the Reports Site"""
 
 from functools import cmp_to_key

--- a/static/css/panelist/first_most_recent_appearances.css
+++ b/static/css/panelist/first_most_recent_appearances.css
@@ -2,4 +2,5 @@
     table.pure-table { max-width: 80rem; }
     col.panelist { width: 15rem; }
     col.panelist-first, col.panelist-most-recent { width: 9rem; }
+    col.panelist-count { width: 6rem; }
 }

--- a/templates/panelist/first_most_recent_appearances.html
+++ b/templates/panelist/first_most_recent_appearances.html
@@ -30,23 +30,27 @@
         <col class="panelist">
         <col class="panelist-first">
         <col class="panelist-most-recent">
+        <col class="panelist-count">
         <col class="panelist-first">
         <col class="panelist-most-recent">
+        <col class="panelist-count">
     </colgroup>
     <thead>
         <tr>
             <th scope="col" rowspan="2">Panelist</th>
-            <th colspan="2">Regular Shows</th>
-            <th colspan="2">All Shows</th>
+            <th colspan="3">Regular Shows</th>
+            <th colspan="3">All Shows</th>
         </tr>
         <tr>
             <!-- Regular Shows -->
             <th scope="col">First</th>
             <th scope="col">Most Recent</th>
+            <th scope="col">Count</th>
 
             <!-- All Shows -->
             <th scope="col">First</th>
-            <th scope="col">Most Recent</th>    
+            <th scope="col">Most Recent</th>
+            <th scope="col">Count</th>
         </tr>
     </thead>
     <tbody>
@@ -64,6 +68,11 @@
             {% else %}
             <td class="no-data">&nbsp;</td>
             {% endif %}
+            {% if panelist_info.count %}
+            <td>{{ panelist_info.count }}</td>
+            {% else %}
+            <td class="no-data">&nbsp;</td>
+            {% endif %}
             {% if panelist_info.first_all %}
             <td><a href="{{ stats_url }}/shows/{{ panelist_info.first_all|replace('-', '/') }}">{{ panelist_info.first_all }}</a></td>
             {% else %}
@@ -71,6 +80,11 @@
             {% endif %}
             {% if panelist_info.most_recent_all %}
             <td><a href="{{ stats_url }}/shows/{{ panelist_info.most_recent_all|replace('-', '/') }}">{{ panelist_info.most_recent_all }}</a></td>
+            {% else %}
+            <td class="no-data">&nbsp;</td>
+            {% endif %}
+            {% if panelist_info.count_all %}
+            <td>{{ panelist_info.count_all }}</td>
             {% else %}
             <td class="no-data">&nbsp;</td>
             {% endif %}

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """Flask WSGI startup file"""
 
 from app import app


### PR DESCRIPTION
Adding two new columns to the Panelist First and Most Recent Appearances report to include appearance counts for regular shows and all shows to complement the existing data in the report.

Also, fixed copyright lines at the top of each code file.