### PR TITLE
Report Column Consistency and Bump Package Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ returns information about panelists, shows, etc.
 
 ## Requirements
 
-- Python 3.6 or newer
+- Python 3.8 or newer
 - MySQL or MariaDB database containing data from the Wait Wait... Don't Tell
   Me! Stats Page database
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Flask==2.0.1
-mysql-connector-python>=8.0.25
-numpy>=1.19.0
-python-dateutil==2.8.1
-python-slugify>=4.0.1
-pytz==2021.1
+Flask==2.0.2
+mysql-connector-python==8.0.28
+numpy==1.22.1
+python-dateutil==2.8.2
+python-slugify==5.0.2
+pytz==2021.3
 us==1.0.0
-uWSGI==2.0.19.1
+uWSGI==2.0.20

--- a/static/css/host/appearance_summary.css
+++ b/static/css/host/appearance_summary.css
@@ -2,4 +2,5 @@
     table.pure-table { max-width: 80rem; }
     col.host { width: 15rem; }
     col.host-first, col.host-most-recent { width: 9rem; }
+    col.host-count { width: 6em; }
 }

--- a/static/css/scorekeeper/appearance_summary.css
+++ b/static/css/scorekeeper/appearance_summary.css
@@ -2,4 +2,5 @@
     table.pure-table { max-width: 80rem; }
     col.scorekeeper { width: 15rem; }
     col.scorekeeper-first, col.scorekeeper-most-recent { width: 9rem; }
+    col.scorekeeper-count { width: 6rem; }
 }

--- a/templates/host/appearance_summary.html
+++ b/templates/host/appearance_summary.html
@@ -28,32 +28,29 @@
 <table class="pure-table pure-table-bordered">
     <colgroup>
         <col class="host">
-        <col class="host-regular-shows">
-        <col class="host-all-shows">
         <col class="host-first">
         <col class="host-most-recent">
+        <col class="host-count">
         <col class="host-first">
         <col class="host-most-recent">
+        <col class="host-count">
     </colgroup>
     <thead>
         <tr>
             <th scope="col" rowspan="2">Host</th>
-            <th colspan="2">Counts</th>
-            <th colspan="2">Regular Shows</th>
-            <th colspan="2">All Shows</th>
+            <th colspan="3">Regular Shows</th>
+            <th colspan="3">All Shows</th>
         </tr>
         <tr>
-            <!-- Counts -->
-            <th scope="col">Regular</th>
-            <th scope="col">All Shows</th>
-
             <!-- Regular Shows -->
             <th scope="col">First</th>
             <th scope="col">Most Recent</th>
+            <th scope="col">Count</th>
 
             <!-- All Shows -->
             <th scope="col">First</th>
-            <th scope="col">Most Recent</th>    
+            <th scope="col">Most Recent</th>
+            <th scope="col">Count</th>
         </tr>
     </thead>
     <tbody>
@@ -61,16 +58,6 @@
         {% set info = summary[host] %}
         <tr>
             <td><a href="{{ stats_url}}/hosts/{{ info.slug }}">{{ info.name }}</a></td>
-            {% if info.regular_shows %}
-            <td>{{ info.regular_shows }}</td>
-            {% else %}
-            <td class="no-data">&nbsp;</td>
-            {% endif %}
-            {% if info.all_shows %}
-            <td>{{ info.all_shows }}</td>
-            {% else %}
-            <td class="no-data">&nbsp;</td>
-            {% endif %}            
             {% if info.first %}
             <td><a href="{{ stats_url }}/shows/{{ info.first|replace('-', '/') }}">{{ info.first }}</a></td>
             {% else %}
@@ -81,6 +68,11 @@
             {% else %}
             <td class="no-data">&nbsp;</td>
             {% endif %}
+            {% if info.regular_shows %}
+            <td>{{ info.regular_shows }}</td>
+            {% else %}
+            <td class="no-data">&nbsp;</td>
+            {% endif %}
             {% if info.first_all %}
             <td><a href="{{ stats_url }}/shows/{{ info.first_all|replace('-', '/') }}">{{ info.first_all }}</a></td>
             {% else %}
@@ -88,6 +80,11 @@
             {% endif %}
             {% if info.most_recent_all %}
             <td><a href="{{ stats_url }}/shows/{{ info.most_recent_all|replace('-', '/') }}">{{ info.most_recent_all }}</a></td>
+            {% else %}
+            <td class="no-data">&nbsp;</td>
+            {% endif %}
+            {% if info.all_shows %}
+            <td>{{ info.all_shows }}</td>
             {% else %}
             <td class="no-data">&nbsp;</td>
             {% endif %}

--- a/templates/scorekeeper/appearance_summary.html
+++ b/templates/scorekeeper/appearance_summary.html
@@ -28,32 +28,29 @@
 <table class="pure-table pure-table-bordered">
     <colgroup>
         <col class="scorekeeper">
-        <col class="scorekeeper-regular-shows">
-        <col class="scorekeeper-all-shows">
         <col class="scorekeeper-first">
         <col class="scorekeeper-most-recent">
+        <col class="scorekeeper-count">
         <col class="scorekeeper-first">
         <col class="scorekeeper-most-recent">
+        <col class="scorekeeper-count">
     </colgroup>
     <thead>
         <tr>
             <th scope="col" rowspan="2">Scorekeeper</th>
-            <th colspan="2">Counts</th>
-            <th colspan="2">Regular Shows</th>
-            <th colspan="2">All Shows</th>
+            <th colspan="3">Regular Shows</th>
+            <th colspan="3">All Shows</th>
         </tr>
         <tr>
-            <!-- Counts -->
-            <th scope="col">Regular</th>
-            <th scope="col">All Shows</th>
-
             <!-- Regular Shows -->
             <th scope="col">First</th>
             <th scope="col">Most Recent</th>
+            <th scope="col">Count</th>
 
             <!-- All Shows -->
             <th scope="col">First</th>
-            <th scope="col">Most Recent</th>    
+            <th scope="col">Most Recent</th>
+            <th scope="col">Count</th>
         </tr>
     </thead>
     <tbody>
@@ -61,16 +58,6 @@
         {% set info = summary[scorekeeper] %}
         <tr>
             <td><a href="{{ stats_url}}/scorekeepers/{{ info.slug }}">{{ info.name }}</a></td>
-            {% if info.regular_shows %}
-            <td>{{ info.regular_shows }}</td>
-            {% else %}
-            <td class="no-data">&nbsp;</td>
-            {% endif %}
-            {% if info.all_shows %}
-            <td>{{ info.all_shows }}</td>
-            {% else %}
-            <td class="no-data">&nbsp;</td>
-            {% endif %}            
             {% if info.first %}
             <td><a href="{{ stats_url }}/shows/{{ info.first|replace('-', '/') }}">{{ info.first }}</a></td>
             {% else %}
@@ -81,6 +68,11 @@
             {% else %}
             <td class="no-data">&nbsp;</td>
             {% endif %}
+            {% if info.regular_shows %}
+            <td>{{ info.regular_shows }}</td>
+            {% else %}
+            <td class="no-data">&nbsp;</td>
+            {% endif %}
             {% if info.first_all %}
             <td><a href="{{ stats_url }}/shows/{{ info.first_all|replace('-', '/') }}">{{ info.first_all }}</a></td>
             {% else %}
@@ -88,6 +80,11 @@
             {% endif %}
             {% if info.most_recent_all %}
             <td><a href="{{ stats_url }}/shows/{{ info.most_recent_all|replace('-', '/') }}">{{ info.most_recent_all }}</a></td>
+            {% else %}
+            <td class="no-data">&nbsp;</td>
+            {% endif %}
+            {% if info.all_shows %}
+            <td>{{ info.all_shows }}</td>
             {% else %}
             <td class="no-data">&nbsp;</td>
             {% endif %}


### PR DESCRIPTION
- Update the Host and Scorekeeper Appearances Summary reports to use the same column order as the Panelist First and Most Recent Appearances report
- Bump package versions in `requirements.txt`
- Make Python 3.8 the minimum supported version in `README.md` due to NumPy requirements